### PR TITLE
Add relevant MIME types to GLSLLanguage constructor

### DIFF
--- a/src/glslplugin/lang/GLSLLanguage.java
+++ b/src/glslplugin/lang/GLSLLanguage.java
@@ -28,6 +28,6 @@ import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory;
  */
 public class GLSLLanguage extends Language {
     public GLSLLanguage() {
-        super("GLSL");
+        super("GLSL", "x-shader/x-vertex", "x-shader/x-fragment");
     }
 }


### PR DESCRIPTION
This allows intellij to recognise the content of \<script type="x-shader/x-fragment"\> elements as GLSL code, for example, which is useful when working with HTML documents and WebGL.

Change suggested by yole at https://stackoverflow.com/questions/28641795/custom-syntax-highlighting-for-content-of-script-elements-depending-on-type-at