### PR TITLE
Update README.md to mention adding resource directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ Licensed under GNU LGPL, see license file.
 ## Compiling
 1. Clone (or download) this repository
 2. Create Intellij project in this directory with Plugin module (Make sure you have official Plugin DevKit installed)
-3. Build -> Prepare plugin for deployment -> You will be notified with plugin jar path
+3. File -> Project Structure -> Modules -> Right-click the `resources` directory -> Mark as Resources
+4. Build -> Prepare plugin for deployment -> You will be notified with plugin jar path


### PR DESCRIPTION
If this step is not completed, the resources directory won't be included in the plugin jar, leading to asserts and missing icons.