### PR TITLE
Fix #42. Add error highlighting to project view

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -79,6 +79,7 @@
         <lang.psiStructureViewFactory language="GLSL"
                                       implementationClass="glslplugin.structureview.GLSLStructureViewFactory"/>
         <annotator language="GLSL" implementationClass="glslplugin.annotation.GLSLAnnotator"/>
+        <problemFileHighlightFilter implementation="glslplugin.extensions.GLSLProblemFileHighlightFilter" />
 
         <intentionAction>
             <className>glslplugin.intentions.vectorcomponents.VectorComponentsIntention</className>

--- a/src/glslplugin/extensions/GLSLProblemFileHighlightFilter.java
+++ b/src/glslplugin/extensions/GLSLProblemFileHighlightFilter.java
@@ -1,0 +1,15 @@
+package glslplugin.extensions;
+
+import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.vfs.VirtualFile;
+import glslplugin.lang.GLSLFileType;
+
+/**
+ * Created by abigail on 29/04/15.
+ */
+public class GLSLProblemFileHighlightFilter implements Condition<VirtualFile> {
+    @Override
+    public boolean value(VirtualFile virtualFile) {
+        return virtualFile.getFileType() instanceof GLSLFileType;
+    }
+}


### PR DESCRIPTION
All that was needed was to tell it that it should check GLSLFileType files for problems.