### PR TITLE
Support for simple #define

### DIFF
--- a/src/glslplugin/GLSLHighlighter.java
+++ b/src/glslplugin/GLSLHighlighter.java
@@ -62,6 +62,8 @@ public class GLSLHighlighter extends SyntaxHighlighterBase {
             { TextAttributesKey.createTextAttributesKey("GLSL.PREPROCESSOR_DIRECTIVE", DefaultLanguageHighlighterColors.METADATA) };
     public static final TextAttributesKey[] GLSL_PRECISION_STATEMENT =
             { TextAttributesKey.createTextAttributesKey("GLSL.PRECISION_STATEMENT", DefaultLanguageHighlighterColors.METADATA) };
+    public static final TextAttributesKey[] GLSL_REDEFINED_TOKEN =
+            { TextAttributesKey.createTextAttributesKey("GLSL.REDEFINED_TOKEN", DefaultLanguageHighlighterColors.METADATA) };
     static final TextAttributesKey[] GLSL_STRING =
             { TextAttributesKey.createTextAttributesKey("GLSL.STRING", DefaultLanguageHighlighterColors.STRING) };
     static final TextAttributesKey[] GLSL_UNKNOWN =

--- a/src/glslplugin/annotation/GLSLAnnotator.java
+++ b/src/glslplugin/annotation/GLSLAnnotator.java
@@ -59,6 +59,7 @@ public class GLSLAnnotator implements com.intellij.lang.annotation.Annotator {
         add(new MissingReturnAnnotation());
         add(new DeclarationAssignmentTypeAnnotation());
         add(new PrecisionStatementAnnotation());
+        add(new RedefinedTokenAnnotation());
     }
 
     public void annotate(@NotNull PsiElement psiElement, @NotNull AnnotationHolder holder) {

--- a/src/glslplugin/annotation/impl/BinaryOperatorTypeAnnotation.java
+++ b/src/glslplugin/annotation/impl/BinaryOperatorTypeAnnotation.java
@@ -23,6 +23,7 @@ import com.intellij.lang.annotation.AnnotationHolder;
 import glslplugin.annotation.Annotator;
 import glslplugin.lang.elements.expressions.GLSLBinaryOperatorExpression;
 import glslplugin.lang.elements.expressions.GLSLExpression;
+import glslplugin.lang.elements.expressions.GLSLOperator;
 import glslplugin.lang.elements.types.GLSLFunctionType;
 import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLTypeCompatibilityLevel;
@@ -40,6 +41,9 @@ public class BinaryOperatorTypeAnnotation extends Annotator<GLSLBinaryOperatorEx
     public void annotate(GLSLBinaryOperatorExpression expr, AnnotationHolder holder) {
         final GLSLExpression left = expr.getLeftOperand();
         final GLSLExpression right = expr.getRightOperand();
+        final GLSLOperator operator = expr.getOperator();
+        if(left == null || right == null || operator == null)return; //There are bigger problems than type compatibility
+
         final GLSLType rightType = right.getType();
         final GLSLType leftType = left.getType();
         final GLSLFunctionType[] operatorAlternatives = expr.getOperatorTypeAlternatives();
@@ -51,7 +55,7 @@ public class BinaryOperatorTypeAnnotation extends Annotator<GLSLBinaryOperatorEx
             }
 
             if (!compatible) {
-                holder.createErrorAnnotation(expr, "Incompatible types as operands of '" + expr.getOperator().getTextRepresentation() + "': '"
+                holder.createErrorAnnotation(expr, "Incompatible types as operands of '" + operator.getTextRepresentation() + "': '"
                         + leftType.getTypename() + "' and '" + rightType.getTypename() + "'");
             }
         }

--- a/src/glslplugin/annotation/impl/ConditionCheckAnnotation.java
+++ b/src/glslplugin/annotation/impl/ConditionCheckAnnotation.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.NotNull;
 
 public class ConditionCheckAnnotation extends Annotator<GLSLStatement> {
     public void annotate(GLSLStatement expr, AnnotationHolder holder) {
-
         if (expr instanceof ConditionStatement) {
             ConditionStatement conditionStatement = (ConditionStatement) expr;
             GLSLCondition condition = conditionStatement.getCondition();
@@ -44,12 +43,8 @@ public class ConditionCheckAnnotation extends Annotator<GLSLStatement> {
                         holder.createErrorAnnotation(condition, "Condition must be a boolean expression.");
                     }
                 }
-            } else if (expr instanceof GLSLWhileStatement) {
-                //todo: get declaration from while statement
             }
         }
-
-
     }
 
     @NotNull

--- a/src/glslplugin/annotation/impl/DeclarationAssignmentTypeAnnotation.java
+++ b/src/glslplugin/annotation/impl/DeclarationAssignmentTypeAnnotation.java
@@ -24,10 +24,7 @@ import glslplugin.annotation.Annotator;
 import glslplugin.lang.elements.declarations.GLSLDeclarator;
 import glslplugin.lang.elements.declarations.GLSLTypeSpecifier;
 import glslplugin.lang.elements.declarations.GLSLVariableDeclaration;
-import glslplugin.lang.elements.expressions.GLSLBinaryOperatorExpression;
 import glslplugin.lang.elements.expressions.GLSLExpression;
-import glslplugin.lang.elements.expressions.GLSLOperator;
-import glslplugin.lang.elements.types.GLSLFunctionType;
 import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLTypeCompatibilityLevel;
 import org.jetbrains.annotations.NotNull;
@@ -45,11 +42,14 @@ public class DeclarationAssignmentTypeAnnotation extends Annotator<GLSLVariableD
 
     @Override
     public void annotate(GLSLVariableDeclaration expr, AnnotationHolder holder) {
-        final GLSLType variableType = expr.getTypeSpecifierNode().getType();
+        GLSLTypeSpecifier typeSpecifier = expr.getTypeSpecifierNode();
+        if(typeSpecifier == null)return;//There are bigger problems than type compatibility
+
+        final GLSLType variableType = typeSpecifier.getType();
         if(!variableType.isValidType())return;
         for(final GLSLDeclarator declarator:expr.getDeclarators()){
-            if(declarator.hasInitializer()){
-                final GLSLExpression initializer = declarator.getInitializerExpression();
+            final GLSLExpression initializer = declarator.getInitializerExpression();
+            if(initializer != null){
                 final GLSLType assignedType = initializer.getType();
                 if(!assignedType.isValidType())continue;
                 if(GLSLTypeCompatibilityLevel.getCompatibilityLevel(assignedType, variableType) == GLSLTypeCompatibilityLevel.INCOMPATIBLE){

--- a/src/glslplugin/annotation/impl/LValueAnnotator.java
+++ b/src/glslplugin/annotation/impl/LValueAnnotator.java
@@ -23,6 +23,7 @@ import com.intellij.lang.annotation.AnnotationHolder;
 import glslplugin.annotation.Annotator;
 import glslplugin.lang.elements.expressions.GLSLAssignmentExpression;
 import glslplugin.lang.elements.expressions.GLSLExpression;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * LValueAnnotation checks for l-values at the left hand side of assignment expressions.
@@ -35,11 +36,14 @@ public class LValueAnnotator extends Annotator<GLSLAssignmentExpression> {
 
     public void annotate(GLSLAssignmentExpression expr, AnnotationHolder holder) {
         GLSLExpression left = expr.getLeftOperand();
+        if(left == null)return;
+
         if (!left.isLValue()) {
             holder.createErrorAnnotation(left, "Left operand of assignment expression is not L-Value.");
         }
     }
 
+    @NotNull
     @Override
     public Class<GLSLAssignmentExpression> getElementType() {
         return GLSLAssignmentExpression.class;

--- a/src/glslplugin/annotation/impl/MemberCheckAnnotation.java
+++ b/src/glslplugin/annotation/impl/MemberCheckAnnotation.java
@@ -22,6 +22,7 @@ package glslplugin.annotation.impl;
 import com.intellij.lang.annotation.AnnotationHolder;
 import glslplugin.annotation.Annotator;
 import glslplugin.lang.elements.GLSLIdentifier;
+import glslplugin.lang.elements.expressions.GLSLExpression;
 import glslplugin.lang.elements.expressions.GLSLFieldSelectionExpression;
 import glslplugin.lang.elements.types.GLSLStructType;
 import glslplugin.lang.elements.types.GLSLType;
@@ -29,10 +30,14 @@ import org.jetbrains.annotations.NotNull;
 
 public class MemberCheckAnnotation extends Annotator<GLSLFieldSelectionExpression> {
     public void annotate(GLSLFieldSelectionExpression expr, AnnotationHolder holder) {
-        GLSLType leftHandType = expr.getLeftHandExpression().getType();
+        GLSLExpression leftHandExpression = expr.getLeftHandExpression();
+        if(leftHandExpression == null)return;
+
+        GLSLType leftHandType = leftHandExpression.getType();
 
         if (leftHandType instanceof GLSLStructType) {
             GLSLIdentifier memberIdentifier = expr.getMemberIdentifier();
+            if(memberIdentifier == null)return;
             GLSLType memberType = leftHandType.getMembers().get(memberIdentifier.getIdentifierName());
             if (memberType == null) {
                 holder.createErrorAnnotation(memberIdentifier, "Unknown member for " + leftHandType.getTypename());

--- a/src/glslplugin/annotation/impl/MissingReturnAnnotation.java
+++ b/src/glslplugin/annotation/impl/MissingReturnAnnotation.java
@@ -40,6 +40,7 @@ public class MissingReturnAnnotation extends Annotator<GLSLFunctionDefinition> {
         if (expr.getType().getBaseType() == GLSLPrimitiveType.VOID) return;
 
         final GLSLCompoundStatement body = expr.getBody();
+        if(body == null)return;
 
         if (body.getTerminatorScope() == GLSLStatement.TerminatorScope.NONE) {
             PsiElement annotationPlace = body;

--- a/src/glslplugin/annotation/impl/RedefinedTokenAnnotation.java
+++ b/src/glslplugin/annotation/impl/RedefinedTokenAnnotation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2010 Jean-Paul Balabanian and Yngve Devik Hammersland
+ *
+ *     This file is part of glsl4idea.
+ *
+ *     Glsl4idea is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as
+ *     published by the Free Software Foundation, either version 3 of
+ *     the License, or (at your option) any later version.
+ *
+ *     Glsl4idea is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package glslplugin.annotation.impl;
+
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.psi.PsiElement;
+import glslplugin.GLSLHighlighter;
+import glslplugin.annotation.Annotator;
+import glslplugin.lang.elements.preprocessor.GLSLElementDropIn;
+import glslplugin.lang.parser.GLSLRedefinedTokenType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Highlights tokens which will be replaced at compile time.
+ * Also shows text they will be replaced as.
+ *
+ * @author Darkyen
+ */
+public class RedefinedTokenAnnotation extends Annotator<GLSLElementDropIn> {
+
+    @Override
+    public void annotate(GLSLElementDropIn expr, AnnotationHolder holder) {
+        PsiElement redefinedToken = expr.getNextSibling();
+        if(redefinedToken == null || !(redefinedToken.getNode().getElementType() instanceof GLSLRedefinedTokenType)) {
+            return; //Something is broken here
+        }
+
+        String message = expr.getOriginalText();
+
+        final Annotation annotation = holder.createInfoAnnotation(redefinedToken, message);
+        annotation.setTextAttributes(GLSLHighlighter.GLSL_REDEFINED_TOKEN[0]);
+    }
+
+    @NotNull
+    @Override
+    public Class<GLSLElementDropIn> getElementType() {
+        return GLSLElementDropIn.class;
+    }
+}

--- a/src/glslplugin/annotation/impl/RedefinedTokenAnnotation.java
+++ b/src/glslplugin/annotation/impl/RedefinedTokenAnnotation.java
@@ -38,11 +38,18 @@ public class RedefinedTokenAnnotation extends Annotator<GLSLElementDropIn> {
 
     @Override
     public void annotate(GLSLElementDropIn expr, AnnotationHolder holder) {
-        PsiElement redefinedToken = expr.getNextSibling();
-        if(redefinedToken == null || !(redefinedToken.getNode().getElementType() instanceof GLSLRedefinedTokenType)) {
-            redefinedToken = expr.getFirstChild();//Case for empty replacement
+
+        PsiElement redefinedToken;
+
+        if(expr.getTextRange().getLength() > 0){
+            redefinedToken = expr; //GLSLUnknownDropIn or something weird
+        }else{
+            redefinedToken = expr.getNextSibling();//GLSLExpressionDropIn found here
             if(redefinedToken == null || !(redefinedToken.getNode().getElementType() instanceof GLSLRedefinedTokenType)) {
-                return; //Something is broken here
+                redefinedToken = expr.getFirstChild();//GLSLEmptyDropIn will be found here
+                if(redefinedToken == null || !(redefinedToken.getNode().getElementType() instanceof GLSLRedefinedTokenType)) {
+                    return; //Something is broken here
+                }
             }
         }
 

--- a/src/glslplugin/annotation/impl/RedefinedTokenAnnotation.java
+++ b/src/glslplugin/annotation/impl/RedefinedTokenAnnotation.java
@@ -40,7 +40,10 @@ public class RedefinedTokenAnnotation extends Annotator<GLSLElementDropIn> {
     public void annotate(GLSLElementDropIn expr, AnnotationHolder holder) {
         PsiElement redefinedToken = expr.getNextSibling();
         if(redefinedToken == null || !(redefinedToken.getNode().getElementType() instanceof GLSLRedefinedTokenType)) {
-            return; //Something is broken here
+            redefinedToken = expr.getFirstChild();//Case for empty replacement
+            if(redefinedToken == null || !(redefinedToken.getNode().getElementType() instanceof GLSLRedefinedTokenType)) {
+                return; //Something is broken here
+            }
         }
 
         String message = expr.getOriginalText();

--- a/src/glslplugin/annotation/impl/VectorComponentsAnnotation.java
+++ b/src/glslplugin/annotation/impl/VectorComponentsAnnotation.java
@@ -23,6 +23,7 @@ import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.openapi.util.TextRange;
 import glslplugin.annotation.Annotator;
 import glslplugin.lang.elements.GLSLIdentifier;
+import glslplugin.lang.elements.expressions.GLSLExpression;
 import glslplugin.lang.elements.expressions.GLSLFieldSelectionExpression;
 import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLVectorType;
@@ -39,11 +40,14 @@ public class VectorComponentsAnnotation extends Annotator<GLSLFieldSelectionExpr
     private static final char[] stpq = {'s', 't', 'p', 'q'};
 
     public void annotate(GLSLFieldSelectionExpression expr, AnnotationHolder holder) {
-        GLSLType leftHandType = expr.getLeftHandExpression().getType();
+        GLSLExpression leftHandExpression = expr.getLeftHandExpression();
+        if(leftHandExpression == null)return;
+        GLSLType leftHandType = leftHandExpression.getType();
 
         if (leftHandType instanceof GLSLVectorType) {
             GLSLVectorType type = (GLSLVectorType) leftHandType;
             GLSLIdentifier memberIdentifier = expr.getMemberIdentifier();
+            if(memberIdentifier == null)return;
             String member = memberIdentifier.getIdentifierName();
             GLSLType glslType = type.getMembers().get(member);
 

--- a/src/glslplugin/components/GLSLTemplatesLoader.java
+++ b/src/glslplugin/components/GLSLTemplatesLoader.java
@@ -36,7 +36,7 @@ public class GLSLTemplatesLoader implements ApplicationComponent {
     }
 
     public void initComponent() {
-        FileTemplateManager fileTemplateManager = FileTemplateManager.getInstance();
+        FileTemplateManager fileTemplateManager = FileTemplateManager.getDefaultInstance();
 
         if (fileTemplateManager.getTemplate("GLSL Shader") == null) {
             final FileTemplate template = fileTemplateManager.addTemplate("GLSL Shader", "glsl");
@@ -46,7 +46,7 @@ public class GLSLTemplatesLoader implements ApplicationComponent {
     }
 
     public void disposeComponent() {
-        FileTemplateManager fileTemplateManager = FileTemplateManager.getInstance();
+        FileTemplateManager fileTemplateManager = FileTemplateManager.getDefaultInstance();
 
         FileTemplate template = fileTemplateManager.getTemplate("GLSL Shader");
         if (template != null) {

--- a/src/glslplugin/extensions/GLSLLineMarkerProvider.java
+++ b/src/glslplugin/extensions/GLSLLineMarkerProvider.java
@@ -23,7 +23,6 @@ import com.intellij.codeHighlighting.Pass;
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.codeInsight.daemon.LineMarkerProvider;
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.util.IconLoader;
 import com.intellij.psi.PsiElement;
 import glslplugin.lang.elements.declarations.GLSLFunctionDeclarationImpl;
 import glslplugin.lang.elements.declarations.GLSLFunctionDefinitionImpl;

--- a/src/glslplugin/intentions/vectorcomponents/VectorComponentsPredicate.java
+++ b/src/glslplugin/intentions/vectorcomponents/VectorComponentsPredicate.java
@@ -22,6 +22,7 @@ package glslplugin.intentions.vectorcomponents;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import glslplugin.lang.elements.GLSLIdentifier;
+import glslplugin.lang.elements.expressions.GLSLExpression;
 import glslplugin.lang.elements.expressions.GLSLFieldSelectionExpression;
 import glslplugin.lang.elements.types.GLSLVectorType;
 
@@ -43,7 +44,9 @@ public class VectorComponentsPredicate {
                     GLSLIdentifier identifier = (GLSLIdentifier) psiElement;
 
                     GLSLFieldSelectionExpression fse = (GLSLFieldSelectionExpression) parent;
-                    if (fse.getLeftHandExpression().getType() instanceof GLSLVectorType) {
+                    GLSLExpression leftHandExpression = fse.getLeftHandExpression();
+                    if(leftHandExpression == null)return false;
+                    if (leftHandExpression.getType() instanceof GLSLVectorType) {
 
                         String parameters = identifier.getIdentifierName();
                         if (checkForMatch(parameters)) {

--- a/src/glslplugin/lang/GLSLFileType.java
+++ b/src/glslplugin/lang/GLSLFileType.java
@@ -35,7 +35,7 @@ import glslplugin.lang.GLSLLanguage;
 public class GLSLFileType extends LanguageFileType {
 
     public GLSLFileType() {
-        super(new GLSLLanguage());
+        super(GLSLLanguage.GLSL_LANGUAGE);
     }
 
     @NotNull

--- a/src/glslplugin/lang/GLSLLanguage.java
+++ b/src/glslplugin/lang/GLSLLanguage.java
@@ -25,7 +25,9 @@ import com.intellij.lang.Language;
  *
  */
 public class GLSLLanguage extends Language {
-    public GLSLLanguage() {
+    public static final GLSLLanguage GLSL_LANGUAGE = new GLSLLanguage();
+
+    private GLSLLanguage() {
         super("GLSL", "x-shader/x-vertex", "x-shader/x-fragment");
     }
 }

--- a/src/glslplugin/lang/GLSLParserDefinition.java
+++ b/src/glslplugin/lang/GLSLParserDefinition.java
@@ -23,7 +23,6 @@ import com.intellij.lang.ASTNode;
 import com.intellij.lang.ParserDefinition;
 import com.intellij.lang.PsiParser;
 import com.intellij.lexer.Lexer;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.FileViewProvider;
 import com.intellij.psi.PsiElement;

--- a/src/glslplugin/lang/elements/GLSLElement.java
+++ b/src/glslplugin/lang/elements/GLSLElement.java
@@ -21,6 +21,7 @@ package glslplugin.lang.elements;
 
 import com.intellij.psi.NavigatablePsiElement;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * GLSLElement is ...
@@ -31,14 +32,22 @@ import com.intellij.psi.PsiElement;
  */
 public interface GLSLElement extends NavigatablePsiElement {
 
+    /**
+     * @return the parent if the parent is of the given class or null otherwise
+     */
+    @Nullable
     <T extends GLSLElement> T findParentByClass(Class<T> clazz);
 
+    /**
+     * @return the parent if the parent is one of the given classes or null otherwise
+     */
+    @Nullable
     GLSLElement findParentByClasses(Class<? extends GLSLElement>... clazzes);
 
     /**
-     * Checks whether this is a descendant of elt.
-     * That is; if elt is an ancestor of this.
-     * Loops through the parent chains and reports whether or not elt is found.
+     * Checks whether this is a descendant of element.
+     * That is; if element is an ancestor of this.
+     * Loops through the parent chains and reports whether or not element is found.
      *
      * @param ancestor the proposed ancestor of this.
      * @return true if ancestor is indeed the ancestor of this, false otherwise.

--- a/src/glslplugin/lang/elements/GLSLElement.java
+++ b/src/glslplugin/lang/elements/GLSLElement.java
@@ -30,13 +30,10 @@ import com.intellij.psi.PsiElement;
  *         Time: 1:33:24 PM
  */
 public interface GLSLElement extends NavigatablePsiElement {
+
     <T extends GLSLElement> T findParentByClass(Class<T> clazz);
 
     GLSLElement findParentByClasses(Class<? extends GLSLElement>... clazzes);
-
-    <T extends GLSLElement> T findPrevSiblingByClass(Class<T> clazz);
-
-    GLSLElement findPrevSiblingByClasses(Class<? extends GLSLElement>... clazzes);
 
     /**
      * Checks whether this is a descendant of elt.

--- a/src/glslplugin/lang/elements/GLSLElementImpl.java
+++ b/src/glslplugin/lang/elements/GLSLElementImpl.java
@@ -58,24 +58,6 @@ public class GLSLElementImpl extends ASTWrapperPsiElement implements GLSLElement
         return null;
     }
 
-    public <T extends GLSLElement> T findPrevSiblingByClass(Class<T> clazz) {
-        //noinspection unchecked
-        return clazz.cast(findPrevSiblingByClasses(clazz));
-    }
-
-    public GLSLElement findPrevSiblingByClasses(Class<? extends GLSLElement>... clazzes) {
-        PsiElement prev = getPrevSibling();
-        while (prev != null) {
-            for (Class<? extends GLSLElement> clazz : clazzes) {
-                if (clazz.isInstance(prev)) {
-                    return clazz.cast(prev);
-                }
-            }
-            prev = prev.getPrevSibling();
-        }
-        return null;
-    }
-
     /**
      * Checks whether this is a descendant of elt.
      * That is; if elt is an ancestor of this.

--- a/src/glslplugin/lang/elements/GLSLElementImpl.java
+++ b/src/glslplugin/lang/elements/GLSLElementImpl.java
@@ -24,6 +24,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import glslplugin.lang.parser.GLSLFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class GLSLElementImpl extends ASTWrapperPsiElement implements GLSLElement {
 
@@ -38,14 +39,16 @@ public class GLSLElementImpl extends ASTWrapperPsiElement implements GLSLElement
 
 
     ////////////////////////////
-    // Utility methods.
+    // Utility methods
 
-    public <T extends GLSLElement> T findParentByClass(Class<T> clazz) {
+    @Nullable
+    public final <T extends GLSLElement> T findParentByClass(Class<T> clazz) {
         //noinspection unchecked
         return clazz.cast(findParentByClasses(clazz));
     }
 
-    public GLSLElement findParentByClasses(Class<? extends GLSLElement>... clazzes) {
+    @Nullable
+    public final GLSLElement findParentByClasses(Class<? extends GLSLElement>... clazzes) {
         PsiElement parent = getParent();
         while (parent != null) {
             for (Class<? extends GLSLElement> clazz : clazzes) {
@@ -58,15 +61,7 @@ public class GLSLElementImpl extends ASTWrapperPsiElement implements GLSLElement
         return null;
     }
 
-    /**
-     * Checks whether this is a descendant of elt.
-     * That is; if elt is an ancestor of this.
-     * Loops through the parent chains and reports whether or not elt is found.
-     *
-     * @param ancestor the proposed ancestor of this.
-     * @return true if ancestor is indeed the ancestor of this, false otherwise.
-     */
-    public boolean isDescendantOf(PsiElement ancestor) {
+    public final boolean isDescendantOf(PsiElement ancestor) {
         PsiElement current = this;
         while (current != null && !(current instanceof GLSLFile)) {
             if (current == ancestor) {

--- a/src/glslplugin/lang/elements/GLSLElementType.java
+++ b/src/glslplugin/lang/elements/GLSLElementType.java
@@ -27,4 +27,8 @@ public class GLSLElementType extends com.intellij.psi.tree.IElementType {
     public GLSLElementType(@NotNull @NonNls String s) {
         super(s, GLSLSupportLoader.GLSL.getLanguage());
     }
+
+    public GLSLElementType(@NotNull @NonNls String debugName, boolean register) {
+        super(debugName, GLSLSupportLoader.GLSL.getLanguage(), register);
+    }
 }

--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -25,7 +25,7 @@ import com.intellij.psi.tree.IFileElementType;
 import glslplugin.lang.GLSLLanguage;
 
 public class GLSLElementTypes {
-    public static final IFileElementType FILE = new IFileElementType(Language.<GLSLLanguage>findInstance(GLSLLanguage.class));
+    public static final IFileElementType FILE = new IFileElementType(Language.findInstance(GLSLLanguage.class));
     public static final IElementType TRANSLATION_UNIT = new GLSLElementType("TRANSLATION_UNIT");
     public static final IElementType BLOCK = new GLSLElementType("BLOCK");
 

--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -23,6 +23,9 @@ import com.intellij.lang.Language;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.IFileElementType;
 import glslplugin.lang.GLSLLanguage;
+import glslplugin.lang.elements.expressions.GLSLLiteral;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
 
 public class GLSLElementTypes {
     public static final IFileElementType FILE = new IFileElementType(Language.findInstance(GLSLLanguage.class));
@@ -130,4 +133,16 @@ public class GLSLElementTypes {
     public static final IElementType FOR_INIT_STATEMENT = new GLSLElementType("FOR_INIT_STATEMENT");
     public static final IElementType FOR_REST_STATEMENT = new GLSLElementType("FOR_REST_STATEMENT");
     public static final IElementType CONDITION = new GLSLElementType("CONDITION");
+
+    //Preprocessor dropins
+    public static final IElementType PREPROCESSED_EXPRESSION = new GLSLElementType("PREPROCESSED_EXPRESSION");
+    public static final class PreprocessedLiteralElementType extends GLSLElementType {
+
+        public final GLSLLiteral.Type type;
+
+        public PreprocessedLiteralElementType(GLSLLiteral.Type type) {
+            super("PREPROCESSED_LITERAL");
+            this.type = type;
+        }
+    }
 }

--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -139,10 +139,12 @@ public class GLSLElementTypes {
     public static final class PreprocessedLiteralElementType extends GLSLElementType {
 
         public final GLSLLiteral.Type type;
+        public final String text;
 
-        public PreprocessedLiteralElementType(GLSLLiteral.Type type) {
+        public PreprocessedLiteralElementType(GLSLLiteral.Type type, String text) {
             super("PREPROCESSED_LITERAL");
             this.type = type;
+            this.text = text;
         }
     }
 }

--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -147,4 +147,5 @@ public class GLSLElementTypes {
             this.text = text;
         }
     }
+    public static final IElementType PREPROCESSED_EMPTY = new GLSLElementType("PREPROCESSED_EMPTY");
 }

--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -140,7 +140,7 @@ public class GLSLElementTypes {
         public final String text;
 
         public PreprocessedExpressionElementType(String text) {
-            super("PREPROCESSED_EXPRESSION");
+            super("PREPROCESSED_EXPRESSION", false);
             this.text = text;
         }
     }
@@ -150,7 +150,7 @@ public class GLSLElementTypes {
         public final String text;
 
         public PreprocessedLiteralElementType(GLSLLiteral.Type type, String text) {
-            super("PREPROCESSED_LITERAL");
+            super("PREPROCESSED_LITERAL", false);
             this.type = type;
             this.text = text;
         }
@@ -160,7 +160,7 @@ public class GLSLElementTypes {
         public final String text;
 
         public PreprocessedUnknownElementType(String text) {
-            super("PREPROCESSED_UNKNOWN");
+            super("PREPROCESSED_UNKNOWN", false);
             this.text = text;
         }
     }

--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -156,4 +156,12 @@ public class GLSLElementTypes {
         }
     }
     public static final IElementType PREPROCESSED_EMPTY = new GLSLElementType("PREPROCESSED_EMPTY");
+    public static final class PreprocessedUnknownElementType extends GLSLElementType {
+        public final String text;
+
+        public PreprocessedUnknownElementType(String text) {
+            super("PREPROCESSED_UNKNOWN");
+            this.text = text;
+        }
+    }
 }

--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -135,7 +135,15 @@ public class GLSLElementTypes {
     public static final IElementType CONDITION = new GLSLElementType("CONDITION");
 
     //Preprocessor dropins
-    public static final IElementType PREPROCESSED_EXPRESSION = new GLSLElementType("PREPROCESSED_EXPRESSION");
+    public static final class PreprocessedExpressionElementType extends GLSLElementType {
+
+        public final String text;
+
+        public PreprocessedExpressionElementType(String text) {
+            super("PREPROCESSED_EXPRESSION");
+            this.text = text;
+        }
+    }
     public static final class PreprocessedLiteralElementType extends GLSLElementType {
 
         public final GLSLLiteral.Type type;

--- a/src/glslplugin/lang/elements/GLSLIdentifier.java
+++ b/src/glslplugin/lang/elements/GLSLIdentifier.java
@@ -23,6 +23,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class GLSLIdentifier extends GLSLElementImpl {
 
@@ -30,14 +31,12 @@ public class GLSLIdentifier extends GLSLElementImpl {
         super(astNode);
     }
 
+    @NotNull
     public String getIdentifierName() {
         return getText();
     }
 
-    public String toString() {
-        return "Identifier: '" + getText() + "'";
-    }
-
+    @Nullable
     private GLSLReferenceElement getRealReference() {
         PsiElement parent = getParent();
         if (parent instanceof GLSLReferenceElement) {
@@ -48,6 +47,7 @@ public class GLSLIdentifier extends GLSLElementImpl {
     }
 
     @Override
+    @Nullable
     public PsiReference getReference() {
         GLSLReferenceElement theRealReference = getRealReference();
         if (theRealReference != null) {
@@ -56,16 +56,10 @@ public class GLSLIdentifier extends GLSLElementImpl {
             return null;
         }
     }
-    /*
+
     @NotNull
     @Override
-    public PsiReference[] getReferences() {
-        GLSLReferenceElement theRealReference = getRealReference();
-        if(theRealReference!=null) {
-            return theRealReference.getReferencesProxy();
-        } else {
-            return PsiReference.EMPTY_ARRAY;
-        }
+    public String toString() {
+        return "Identifier: '" + getText() + "'";
     }
-    */
 }

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -24,6 +24,7 @@ import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.elements.declarations.*;
 import glslplugin.lang.elements.expressions.*;
 import glslplugin.lang.elements.preprocessor.GLSLExpressionDropIn;
+import glslplugin.lang.elements.preprocessor.GLSLLiteralDropIn;
 import glslplugin.lang.elements.statements.*;
 
 /**
@@ -48,6 +49,10 @@ public class GLSLPsiElementFactory {
 
         // preprocessor shortcuts
         if (type == GLSLElementTypes.PREPROCESSED_EXPRESSION) return new GLSLExpressionDropIn(node);
+        if (type instanceof GLSLElementTypes.PreprocessedLiteralElementType){
+            GLSLElementTypes.PreprocessedLiteralElementType t = (GLSLElementTypes.PreprocessedLiteralElementType) type;
+            return new GLSLLiteralDropIn(node, t.type, t.text);
+        }
 
         // translation unit
         if (type == GLSLElementTypes.TRANSLATION_UNIT) return new GLSLTranslationUnit(node);

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -24,7 +24,6 @@ import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.elements.declarations.*;
 import glslplugin.lang.elements.expressions.*;
 import glslplugin.lang.elements.statements.*;
-import glslplugin.lang.parser.GLSLRedefinedTokenType;
 
 /**
  * GLSLPsiElementFactory defines the interface for the GLSLElement factory.

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -24,6 +24,7 @@ import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.elements.declarations.*;
 import glslplugin.lang.elements.expressions.*;
 import glslplugin.lang.elements.statements.*;
+import glslplugin.lang.parser.GLSLRedefinedTokenType;
 
 /**
  * GLSLPsiElementFactory defines the interface for the GLSLElement factory.
@@ -127,6 +128,8 @@ public class GLSLPsiElementFactory {
         if (type == GLSLElementTypes.STRUCT_DECLARATION) return new GLSLStructDeclaration(node);
         if (type == GLSLElementTypes.STRUCT_DECLARATOR_LIST) return new GLSLDeclaratorList(node);
         if (type == GLSLElementTypes.STRUCT_DECLARATOR) return new GLSLDeclarator(node);
+
+        if (type instanceof GLSLRedefinedTokenType) return new GLSLRedefinedTokenType.GLSLRedefinedPsiElement(node, (GLSLRedefinedTokenType) type);
 
         return null;
     }

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -49,7 +49,10 @@ public class GLSLPsiElementFactory {
         IElementType type = node.getElementType();
 
         // preprocessor shortcuts
-        if (type == GLSLElementTypes.PREPROCESSED_EXPRESSION) return new GLSLExpressionDropIn(node);
+        if (type instanceof GLSLElementTypes.PreprocessedExpressionElementType){
+            GLSLElementTypes.PreprocessedExpressionElementType t = (GLSLElementTypes.PreprocessedExpressionElementType) type;
+            return new GLSLExpressionDropIn(node, t.text);
+        }
         if (type instanceof GLSLElementTypes.PreprocessedLiteralElementType){
             GLSLElementTypes.PreprocessedLiteralElementType t = (GLSLElementTypes.PreprocessedLiteralElementType) type;
             return new GLSLLiteralDropIn(node, t.type, t.text);

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -23,6 +23,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.elements.declarations.*;
 import glslplugin.lang.elements.expressions.*;
+import glslplugin.lang.elements.preprocessor.GLSLEmptyDropIn;
 import glslplugin.lang.elements.preprocessor.GLSLExpressionDropIn;
 import glslplugin.lang.elements.preprocessor.GLSLLiteralDropIn;
 import glslplugin.lang.elements.statements.*;
@@ -53,6 +54,7 @@ public class GLSLPsiElementFactory {
             GLSLElementTypes.PreprocessedLiteralElementType t = (GLSLElementTypes.PreprocessedLiteralElementType) type;
             return new GLSLLiteralDropIn(node, t.type, t.text);
         }
+        if (type == GLSLElementTypes.PREPROCESSED_EMPTY) return new GLSLEmptyDropIn(node);
 
         // translation unit
         if (type == GLSLElementTypes.TRANSLATION_UNIT) return new GLSLTranslationUnit(node);

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -26,6 +26,7 @@ import glslplugin.lang.elements.expressions.*;
 import glslplugin.lang.elements.preprocessor.GLSLEmptyDropIn;
 import glslplugin.lang.elements.preprocessor.GLSLExpressionDropIn;
 import glslplugin.lang.elements.preprocessor.GLSLLiteralDropIn;
+import glslplugin.lang.elements.preprocessor.GLSLUnknownDropIn;
 import glslplugin.lang.elements.statements.*;
 
 /**
@@ -58,6 +59,10 @@ public class GLSLPsiElementFactory {
             return new GLSLLiteralDropIn(node, t.type, t.text);
         }
         if (type == GLSLElementTypes.PREPROCESSED_EMPTY) return new GLSLEmptyDropIn(node);
+        if (type instanceof GLSLElementTypes.PreprocessedUnknownElementType){
+            GLSLElementTypes.PreprocessedUnknownElementType t = (GLSLElementTypes.PreprocessedUnknownElementType) type;
+            return new GLSLUnknownDropIn(node, t.text);
+        }
 
         // translation unit
         if (type == GLSLElementTypes.TRANSLATION_UNIT) return new GLSLTranslationUnit(node);

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -129,8 +129,6 @@ public class GLSLPsiElementFactory {
         if (type == GLSLElementTypes.STRUCT_DECLARATOR_LIST) return new GLSLDeclaratorList(node);
         if (type == GLSLElementTypes.STRUCT_DECLARATOR) return new GLSLDeclarator(node);
 
-        if (type instanceof GLSLRedefinedTokenType) return new GLSLRedefinedTokenType.GLSLRedefinedPsiElement(node, (GLSLRedefinedTokenType) type);
-
         return null;
     }
 }

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -23,6 +23,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.elements.declarations.*;
 import glslplugin.lang.elements.expressions.*;
+import glslplugin.lang.elements.preprocessor.GLSLExpressionDropIn;
 import glslplugin.lang.elements.statements.*;
 
 /**
@@ -44,6 +45,9 @@ public class GLSLPsiElementFactory {
             return null;
         }
         IElementType type = node.getElementType();
+
+        // preprocessor shortcuts
+        if (type == GLSLElementTypes.PREPROCESSED_EXPRESSION) return new GLSLExpressionDropIn(node);
 
         // translation unit
         if (type == GLSLElementTypes.TRANSLATION_UNIT) return new GLSLTranslationUnit(node);

--- a/src/glslplugin/lang/elements/declarations/GLSLArraySpecifier.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLArraySpecifier.java
@@ -22,6 +22,9 @@ package glslplugin.lang.elements.declarations;
 import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.GLSLElementImpl;
 import glslplugin.lang.elements.expressions.GLSLExpression;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLArrayDeclarator is ...
@@ -39,12 +42,14 @@ public class GLSLArraySpecifier extends GLSLElementImpl {
         return findChildByClass(GLSLExpression.class) != null;
     }
 
+    @Nullable
     public GLSLExpression getSizeExpression() {
         GLSLExpression expr = findChildByClass(GLSLExpression.class);
         if (expr != null) {
             return expr;
         } else {
-            throw new RuntimeException("Check for array size expression before asking for it!");
+            Logger.getLogger("GLSLArraySpecifier").warning("Check for array size expression before asking for it!");
+            return null;
         }
     }
 

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaration.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaration.java
@@ -21,6 +21,7 @@ package glslplugin.lang.elements.declarations;
 
 import glslplugin.lang.elements.GLSLElement;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * GLSLDeclaration is a common interface for all declarations;
@@ -33,8 +34,10 @@ import org.jetbrains.annotations.NotNull;
 public interface GLSLDeclaration extends GLSLElement {
     GLSLDeclaration[] NO_DECLARATIONS = new GLSLDeclaration[0];
 
+    @Nullable
     GLSLTypeSpecifier getTypeSpecifierNode();
 
+    @Nullable
     GLSLQualifierList getQualifierList();
 
     @NotNull

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaration.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaration.java
@@ -31,6 +31,8 @@ import org.jetbrains.annotations.NotNull;
  *         Time: 12:39:33 AM
  */
 public interface GLSLDeclaration extends GLSLElement {
+    GLSLDeclaration[] NO_DECLARATIONS = new GLSLDeclaration[0];
+
     GLSLTypeSpecifier getTypeSpecifierNode();
 
     GLSLQualifierList getQualifierList();

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclarationImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclarationImpl.java
@@ -38,6 +38,7 @@ public class GLSLDeclarationImpl extends GLSLElementImpl implements GLSLDeclarat
     }
 
     private static final GLSLQualifier[] NO_QUALIFIERS = new GLSLQualifier[0];
+    @NotNull
     public GLSLQualifier[] getQualifiers() {
         final GLSLQualifierList qualifierList = getQualifierList();
         if(qualifierList == null){
@@ -60,6 +61,20 @@ public class GLSLDeclarationImpl extends GLSLElementImpl implements GLSLDeclarat
     @Nullable
     public GLSLTypeSpecifier getTypeSpecifierNode() {
         return findChildByClass(GLSLTypeSpecifier.class);
+    }
+
+    /**
+     * Returns "(unknown)" if getTypeSpecifierNode() returns null
+     * @return result of getTypeSpecifierNode().getTypeName()
+     */
+    @NotNull
+    public String getTypeSpecifierNodeTypeName(){
+        GLSLTypeSpecifier specifier = getTypeSpecifierNode();
+        if(specifier != null){
+            return specifier.getTypeName();
+        }else {
+            return "(unknown)";
+        }
     }
 
     @Nullable

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclarationList.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclarationList.java
@@ -25,9 +25,12 @@ import com.intellij.psi.PsiErrorElement;
 import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.elements.GLSLElementImpl;
 import glslplugin.lang.elements.GLSLTokenTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * NewDeclarationList is ...
@@ -41,6 +44,7 @@ public class GLSLDeclarationList extends GLSLElementImpl {
         super(node);
     }
 
+    @NotNull
     public GLSLDeclaration[] getDeclarations() {
         // convert the list of children to a list of GLSLStatement objects while performing sanity check.
         PsiElement[] children = getChildren();
@@ -53,7 +57,7 @@ public class GLSLDeclarationList extends GLSLElementImpl {
                 if (node != null) {
                     final IElementType type = node.getElementType();
                     if (!GLSLTokenTypes.COMMENTS.contains(type)) {
-                        throw new RuntimeException("Parameter declaration list contains non-comment, non-expression element.");
+                        Logger.getLogger("GLSLDeclarationList").warning("Parameter declaration list contains non-comment, non-expression element. ("+type+")");
                     }
                 }
             }
@@ -61,14 +65,18 @@ public class GLSLDeclarationList extends GLSLElementImpl {
         return result.toArray(new GLSLDeclaration[result.size()]);
     }
 
+    @Nullable
     public GLSLDeclaration getLastDeclaration() {
         GLSLDeclaration[] declarations = getDeclarations();
-        return declarations[declarations.length - 1];
+        if(declarations.length == 0)return null;
+        else return declarations[declarations.length - 1];
     }
 
+    @Nullable
     public GLSLDeclaration getFirstDeclaration() {
         GLSLDeclaration[] declarations = getDeclarations();
-        return declarations[0];
+        if(declarations.length == 0)return null;
+        else return declarations[0];
     }
 
     @Override

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclarator.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclarator.java
@@ -23,6 +23,9 @@ import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.GLSLIdentifier;
 import glslplugin.lang.elements.expressions.GLSLExpression;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLDeclarator represents a local or global variable declaration.
@@ -47,15 +50,21 @@ public class GLSLDeclarator extends GLSLDeclaratorBase {
         return findChildByClass(GLSLIdentifier.class) != null;
     }
 
+    /**
+     * @return initializer expression or null if hasInitializer() returned false
+     */
+    @Nullable
     public GLSLExpression getInitializerExpression() {
         final GLSLInitializer init = findChildByClass(GLSLInitializer.class);
         if (init != null) {
             return init.getInitializerExpression();
         } else {
-            throw new RuntimeException("Check for initializer before asking for it!");
+            Logger.getLogger("GLSLDeclarator").warning("Check for initializer before asking for it!");
+            return null;
         }
     }
 
+    @Nullable
     public GLSLArraySpecifier getArraySpecifier() {
         return findChildByClass(GLSLArraySpecifier.class);
     }

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclarator.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclarator.java
@@ -42,24 +42,12 @@ public class GLSLDeclarator extends GLSLDeclaratorBase {
         super(astNode);
     }
 
-    public boolean hasInitializer() {
-        return findChildByClass(GLSLInitializer.class) != null;
-    }
-
-    public boolean hasIdentifier() {
-        return findChildByClass(GLSLIdentifier.class) != null;
-    }
-
-    /**
-     * @return initializer expression or null if hasInitializer() returned false
-     */
     @Nullable
     public GLSLExpression getInitializerExpression() {
         final GLSLInitializer init = findChildByClass(GLSLInitializer.class);
         if (init != null) {
             return init.getInitializerExpression();
         } else {
-            Logger.getLogger("GLSLDeclarator").warning("Check for initializer before asking for it!");
             return null;
         }
     }

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaratorBase.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaratorBase.java
@@ -50,6 +50,7 @@ public class GLSLDeclaratorBase extends GLSLElementImpl {
         }
     }
 
+    @NotNull
     public String getIdentifierName() {
         PsiElement idElement = getFirstChild();
         if (idElement instanceof GLSLIdentifier) {
@@ -59,10 +60,12 @@ public class GLSLDeclaratorBase extends GLSLElementImpl {
         }
     }
 
+    @Nullable
     private GLSLArraySpecifier getArraySpecifier() {
         return findChildByClass(GLSLArraySpecifier.class);
     }
 
+    @Nullable
     public GLSLDeclaration getParentDeclaration() {
         return findParentByClass(GLSLDeclarationImpl.class);
     }
@@ -82,6 +85,7 @@ public class GLSLDeclaratorBase extends GLSLElementImpl {
         }
     }
 
+    @NotNull
     public GLSLQualifiedType getQualifiedType() {
         final GLSLType type = getType();
         final GLSLDeclaration declaration = getParentDeclaration();

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaratorBase.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaratorBase.java
@@ -77,6 +77,7 @@ public class GLSLDeclaratorBase extends GLSLElementImpl {
 
         if(declaration == null)return GLSLTypes.UNKNOWN_TYPE;
         GLSLTypeSpecifier declarationType = declaration.getTypeSpecifierNode();
+        if(declarationType == null)return GLSLTypes.UNKNOWN_TYPE;
 
         if (arraySpecifier != null) {
             return new GLSLArrayType(declarationType.getType(), declarationType.getArraySpecifierNode());

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaratorList.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaratorList.java
@@ -20,6 +20,7 @@
 package glslplugin.lang.elements.declarations;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import glslplugin.lang.elements.GLSLElementImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,7 +46,10 @@ public class GLSLDeclaratorList extends GLSLElementImpl implements Iterable<GLSL
 
     @Nullable
     public GLSLVariableDeclaration getParentDeclaration() {
-        return findParentByClass(GLSLVariableDeclaration.class);
+        PsiElement parent = getParent();
+        if(parent instanceof GLSLVariableDeclaration){
+            return (GLSLVariableDeclaration)parent;
+        }else return null;
     }
 
     @Override

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaratorList.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaratorList.java
@@ -22,6 +22,7 @@ package glslplugin.lang.elements.declarations;
 import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.GLSLElementImpl;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
 
@@ -42,8 +43,9 @@ public class GLSLDeclaratorList extends GLSLElementImpl implements Iterable<GLSL
         return findChildrenByClass(GLSLDeclarator.class);
     }
 
+    @Nullable
     public GLSLVariableDeclaration getParentDeclaration() {
-        return (GLSLVariableDeclaration) getParent();
+        return findParentByClass(GLSLVariableDeclaration.class);
     }
 
     @Override

--- a/src/glslplugin/lang/elements/declarations/GLSLFunctionDeclarationImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLFunctionDeclarationImpl.java
@@ -23,6 +23,7 @@ import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.types.GLSLBasicFunctionType;
 import glslplugin.lang.elements.types.GLSLFunctionType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * GLSLFunctionDeclarationImpl is the psi implementation of a function declaration.
@@ -36,17 +37,17 @@ public class GLSLFunctionDeclarationImpl extends GLSLSingleDeclarationImpl imple
 
     @NotNull
     public GLSLParameterDeclaration[] getParameters() {
-        GLSLDeclaration[] declarations = getParameterList().getDeclarations();
-        return castToParameters(declarations);
+        GLSLDeclarationList parameterList = getParameterList();
+        if(parameterList == null)return GLSLParameterDeclaration.NO_PARAMETER_DECLARATIONS;
+        return castToParameters(parameterList.getDeclarations());
+    }
+
+    @Nullable
+    public GLSLDeclarationList getParameterList() {
+        return findChildByClass(GLSLDeclarationList.class);
     }
 
     @NotNull
-    public GLSLDeclarationList getParameterList() {
-        final GLSLDeclarationList list = findChildByClass(GLSLDeclarationList.class);
-        assert list != null;
-        return list;
-    }
-
     private static GLSLParameterDeclaration[] castToParameters(GLSLDeclaration[] declarations) {
         GLSLParameterDeclaration[] parameters = new GLSLParameterDeclaration[declarations.length];
         for (int i = 0; i < declarations.length; i++) {
@@ -65,10 +66,10 @@ public class GLSLFunctionDeclarationImpl extends GLSLSingleDeclarationImpl imple
                 b.append(",");
             }
             first = false;
-            b.append(declarator.getTypeSpecifierNode().getTypeName());
+            b.append(declarator.getTypeSpecifierNodeTypeName());
         }
         b.append(") : ");
-        b.append(getTypeSpecifierNode().getTypeName());
+        b.append(getTypeSpecifierNodeTypeName());
         return b.toString();
     }
 

--- a/src/glslplugin/lang/elements/declarations/GLSLFunctionDefinition.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLFunctionDefinition.java
@@ -20,7 +20,6 @@
 package glslplugin.lang.elements.declarations;
 
 import glslplugin.lang.elements.statements.GLSLCompoundStatement;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**

--- a/src/glslplugin/lang/elements/declarations/GLSLFunctionDefinition.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLFunctionDefinition.java
@@ -21,6 +21,7 @@ package glslplugin.lang.elements.declarations;
 
 import glslplugin.lang.elements.statements.GLSLCompoundStatement;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * NewFunctionDefinition is ...
@@ -30,6 +31,10 @@ import org.jetbrains.annotations.NotNull;
  *         Time: 12:33:24 PM
  */
 public interface GLSLFunctionDefinition extends GLSLFunctionDeclaration {
-    @NotNull
+
+    /**
+     * @return Body of function definition, null only on malformed source
+     */
+    @Nullable
     GLSLCompoundStatement getBody();
 }

--- a/src/glslplugin/lang/elements/declarations/GLSLFunctionDefinitionImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLFunctionDefinitionImpl.java
@@ -21,6 +21,7 @@ package glslplugin.lang.elements.declarations;
 
 import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.statements.GLSLCompoundStatement;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * NewFunctionDefinition is ...
@@ -34,10 +35,9 @@ public class GLSLFunctionDefinitionImpl extends GLSLFunctionDeclarationImpl impl
         super(node);
     }
 
+    @Nullable
     public GLSLCompoundStatement getBody() {
-        GLSLCompoundStatement statement = findChildByClass(GLSLCompoundStatement.class);
-        assert statement != null;
-        return statement;
+        return findChildByClass(GLSLCompoundStatement.class);
     }
 
     @Override

--- a/src/glslplugin/lang/elements/declarations/GLSLInitializer.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLInitializer.java
@@ -20,8 +20,10 @@
 package glslplugin.lang.elements.declarations;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 import glslplugin.lang.elements.expressions.GLSLExpression;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * GLSLInitializer is ...
@@ -35,8 +37,12 @@ public class GLSLInitializer extends GLSLExpression {
         super(astNode);
     }
 
-    GLSLExpression getInitializerExpression() {
-        return (GLSLExpression) getFirstChild();
+    @Nullable
+    public GLSLExpression getInitializerExpression() {
+        PsiElement result = getFirstChild();
+        if(result instanceof GLSLExpression){
+            return (GLSLExpression)result;
+        }else return null;
     }
 
     @Override

--- a/src/glslplugin/lang/elements/declarations/GLSLParameterDeclaration.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLParameterDeclaration.java
@@ -30,6 +30,8 @@ import org.jetbrains.annotations.NotNull;
  *         Time: 2:04:56 PM
  */
 public class GLSLParameterDeclaration extends GLSLSingleDeclarationImpl {
+    public static final GLSLParameterDeclaration[] NO_PARAMETER_DECLARATIONS = new GLSLParameterDeclaration[0];
+
     public GLSLParameterDeclaration(@NotNull ASTNode astNode) {
         super(astNode);
     }
@@ -41,7 +43,7 @@ public class GLSLParameterDeclaration extends GLSLSingleDeclarationImpl {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder("Parameter Declaration: ");
-        b.append(getTypeSpecifierNode().getTypeName());
+        b.append(getTypeSpecifierNodeTypeName());
         if (hasDeclarator()) {
             b.append(getDeclaredName());
         }

--- a/src/glslplugin/lang/elements/declarations/GLSLQualifier.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLQualifier.java
@@ -26,6 +26,9 @@ import glslplugin.lang.elements.GLSLElementImpl;
 import glslplugin.lang.elements.GLSLTokenTypes;
 import glslplugin.lang.elements.types.GLSLTypeQualifier;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLQualifier is all kinds of qualifiers combined into a single class.
@@ -108,26 +111,31 @@ public class GLSLQualifier extends GLSLElementImpl {
         }
     }
 
-
+    @Nullable
     public Qualifier getQualifier() {
         PsiElement qualifier = getFirstChild();
-        assert qualifier != null;
+        if(qualifier == null)return null;
         ASTNode qualifierNode = qualifier.getNode();
-        assert qualifierNode != null;
+        if(qualifierNode == null)return null;
         return getQualifierFromType(qualifierNode.getElementType());
     }
 
+    @Nullable
     public GLSLTypeQualifier getQualifierType() {
-        return getQualifier().getType();
+        Qualifier qualifier = getQualifier();
+        if(qualifier == null)return null;
+        return qualifier.getType();
     }
 
+    @Nullable
     private Qualifier getQualifierFromType(IElementType elt) {
         for (Qualifier qualifier : Qualifier.values()) {
             if (qualifier.getCorrespondingElement() == elt) {
                 return qualifier;
             }
         }
-        throw new RuntimeException("Unsupported element type: " + elt);
+        Logger.getLogger("GLSLQualifier").warning("Unsupported element type: " + elt);
+        return null;
     }
 
     public GLSLQualifier(@NotNull ASTNode astNode) {

--- a/src/glslplugin/lang/elements/declarations/GLSLQualifierList.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLQualifierList.java
@@ -39,6 +39,7 @@ public class GLSLQualifierList extends GLSLElementImpl implements Iterable<GLSLQ
         super(astNode);
     }
 
+    @NotNull
     public GLSLQualifier[] getQualifiers() {
         return findChildrenByClass(GLSLQualifier.class);
     }

--- a/src/glslplugin/lang/elements/declarations/GLSLTypeDefinition.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLTypeDefinition.java
@@ -49,6 +49,7 @@ public class GLSLTypeDefinition extends GLSLElementImpl implements GLSLTypedElem
         super(astNode);
     }
 
+    @Nullable
     private String getTypeNameInternal() {
         final PsiElement[] children = getChildren();
         if (children.length > 1) {
@@ -74,19 +75,21 @@ public class GLSLTypeDefinition extends GLSLElementImpl implements GLSLTypedElem
         }
     }
 
-    public GLSLTypeDefinition getTypeDefinition() {
-        return this;
-    }
-
     // TODO: Add getMemberDeclarations, findMember(String), etc...
+
+    @Nullable
     public GLSLDeclarationList getDeclarationList() {
-        GLSLDeclarationList list = findChildByClass(GLSLDeclarationList.class);
-        assert list != null;
-        return list;
+        return findChildByClass(GLSLDeclarationList.class);
     }
 
+    @NotNull
     public GLSLDeclaration[] getDeclarations() {
-        return getDeclarationList().getDeclarations();
+        GLSLDeclarationList declarationList = getDeclarationList();
+        if(declarationList == null){
+            return GLSLDeclaration.NO_DECLARATIONS;
+        }else{
+            return declarationList.getDeclarations();
+        }
     }
 
     @NotNull

--- a/src/glslplugin/lang/elements/declarations/GLSLTypeSpecifier.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLTypeSpecifier.java
@@ -27,6 +27,7 @@ import glslplugin.lang.elements.types.GLSLArrayType;
 import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLTypes;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  *
@@ -39,6 +40,7 @@ public class GLSLTypeSpecifier extends GLSLElementImpl {
         super(astNode);
     }
 
+    @Nullable
     public GLSLArraySpecifier getArraySpecifierNode() {
         PsiElement[] children = getChildren();
         if (children.length == 2) {
@@ -50,6 +52,7 @@ public class GLSLTypeSpecifier extends GLSLElementImpl {
         return null;
     }
 
+    @NotNull
     public GLSLType getType() {
         // GLSLTypedElement is either a type definition or type reference
         GLSLTypedElement reference = findChildByClass(GLSLTypedElement.class);
@@ -65,6 +68,7 @@ public class GLSLTypeSpecifier extends GLSLElementImpl {
         }
     }
 
+    @NotNull
     public String getTypeName() {
         return getType().getTypename();
     }
@@ -74,6 +78,7 @@ public class GLSLTypeSpecifier extends GLSLElementImpl {
         return "Type Specifier: " + getTypeName();
     }
 
+    @Nullable
     public GLSLTypedElement getTypeDefinition() {
         return findChildByClass(GLSLTypeDefinition.class);
     }

--- a/src/glslplugin/lang/elements/declarations/GLSLTypename.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLTypename.java
@@ -30,6 +30,9 @@ import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLTypes;
 import glslplugin.lang.parser.GLSLFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLTypeReference represents a type-specifier which specifies a custom type.
@@ -44,9 +47,10 @@ public class GLSLTypename extends GLSLElementImpl implements GLSLTypedElement, G
         super(astNode);
     }
 
+    @Nullable
     public GLSLTypeDefinition getTypeDefinition() {
         GLSLIdentifier id = findChildByClass(GLSLIdentifier.class);
-        assert id != null;
+        if(id == null)return null;
         PsiReference ref = id.getReference();
         if (ref != null) {
             PsiElement elt = ref.resolve();
@@ -131,14 +135,12 @@ public class GLSLTypename extends GLSLElementImpl implements GLSLTypedElement, G
             if (childType == GLSLTokenTypes.SAMPLER1DSHADOW_TYPE) return GLSLTypes.SAMPLER1D_SHADOW;
             if (childType == GLSLTokenTypes.SAMPLER2DSHADOW_TYPE) return GLSLTypes.SAMPLER2D_SHADOW;
         }
-        throw new RuntimeException("Unknown element type: '" + type + "'");
+
+        Logger.getLogger("GLSLTypename").warning("Unknown element type: '" + type + "'");
+        return GLSLTypes.UNKNOWN_TYPE;
     }
 
-    public boolean isNamed() {
-        // The referenced struct obviously needs to be named.
-        return true;
-    }
-
+    @Nullable
     public GLSLDeclarationList getDeclarationList() {
         final GLSLTypeDefinition definition = getTypeDefinition();
         if (definition != null) {
@@ -148,6 +150,7 @@ public class GLSLTypename extends GLSLElementImpl implements GLSLTypedElement, G
         }
     }
 
+    @Nullable
     public GLSLTypeReference getReferenceProxy() {
         GLSLTypeDefinition definition = findTypeReference();
         if (definition != null) {
@@ -157,6 +160,7 @@ public class GLSLTypename extends GLSLElementImpl implements GLSLTypedElement, G
         }
     }
 
+    @Nullable
     private GLSLTypeDefinition findTypeReference() {
         PsiElement current = getPrevSibling();
         GLSLTypeDefinition result = null;
@@ -213,6 +217,7 @@ public class GLSLTypename extends GLSLElementImpl implements GLSLTypedElement, G
         return null;
     }
 
+    @Nullable
     private GLSLTypeDefinition checkDeclarationForType(GLSLDeclaration declaration) {
         final GLSLTypeSpecifier specifier = declaration.getTypeSpecifierNode();
         if(specifier == null)return null;
@@ -231,12 +236,13 @@ public class GLSLTypename extends GLSLElementImpl implements GLSLTypedElement, G
         return "Struct Reference: '" + getTypename() + "'";
     }
 
+    @NotNull
     public GLSLDeclaration[] getDeclarations() {
         final GLSLTypeDefinition definition = getTypeDefinition();
         if (definition != null) {
             return definition.getDeclarations();
         } else {
-            return null;
+            return GLSLDeclaration.NO_DECLARATIONS;
         }
     }
 
@@ -250,6 +256,7 @@ public class GLSLTypename extends GLSLElementImpl implements GLSLTypedElement, G
         }
     }
 
+    @NotNull
     public String getTypename() {
         return getText();
     }

--- a/src/glslplugin/lang/elements/declarations/GLSLTypename.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLTypename.java
@@ -78,6 +78,7 @@ public class GLSLTypename extends GLSLElementImpl implements GLSLTypedElement, G
 
         if (type == GLSLElementTypes.TYPE_SPECIFIER_PRIMITIVE) {
             final ASTNode child = node.getFirstChildNode();
+            if(child == null)return GLSLTypes.UNKNOWN_TYPE; //This means broken tree
             final IElementType childType = child.getElementType();
 
             if (childType == GLSLTokenTypes.VOID_TYPE) return GLSLTypes.VOID;

--- a/src/glslplugin/lang/elements/expressions/GLSLAssignmentExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLAssignmentExpression.java
@@ -41,6 +41,11 @@ public class GLSLAssignmentExpression extends GLSLBinaryOperatorExpression {
 
     @Override
     public String toString() {
-        return "Assignment: " + getOperator().getTextRepresentation();
+        GLSLOperator operator = getOperator();
+        if(operator == null){
+            return "Assignment: (unknown)";
+        }else{
+            return "Assignment: " + operator.getTextRepresentation();
+        }
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLBinaryOperatorExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLBinaryOperatorExpression.java
@@ -24,6 +24,9 @@ import glslplugin.lang.elements.types.GLSLFunctionType;
 import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLTypes;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLBinaryOperatorExpression is an expression from two operands and one operator between them.
@@ -37,27 +40,26 @@ public class GLSLBinaryOperatorExpression extends GLSLOperatorExpression {
         super(astNode);
     }
 
+    @Nullable
     public GLSLExpression getLeftOperand() {
         GLSLExpression[] operands = getOperands();
         if (operands.length == 2) {
             return operands[0];
         } else {
-            throw new RuntimeException("Binary operator with " + operands.length + " operand(s).");
+            Logger.getLogger("GLSLBinaryOperatorExpression").warning("Binary operator with " + operands.length + " operand(s).");
+            return null;
         }
     }
 
+    @Nullable
     public GLSLExpression getRightOperand() {
         GLSLExpression[] operands = getOperands();
         if (operands.length == 2) {
             return operands[1];
         } else {
-            throw new RuntimeException("Binary operator with " + operands.length + " operand(s).");
+            Logger.getLogger("GLSLBinaryOperatorExpression").warning("Binary operator with " + operands.length + " operand(s).");
+            return null;
         }
-    }
-
-
-    public String toString() {
-        return "Binary Operator: '" + getOperator().getTextRepresentation() + "'";
     }
 
     @NotNull
@@ -84,11 +86,25 @@ public class GLSLBinaryOperatorExpression extends GLSLOperatorExpression {
         */
     }
 
+    @NotNull
     public GLSLFunctionType[] getOperatorTypeAlternatives() {
+        GLSLExpression leftExpr = getLeftOperand();
+        GLSLExpression rightExpr = getRightOperand();
         GLSLOperator operator = getOperator();
-        GLSLType leftType = getLeftOperand().getType();
-        GLSLType rightType = getRightOperand().getType();
+        if(leftExpr == null || rightExpr == null || operator == null)return GLSLFunctionType.EMPTY_ARRAY;
+
+        GLSLType leftType = leftExpr.getType();
+        GLSLType rightType = rightExpr.getType();
 
         return operator.getFunctionTypeAlternatives(new GLSLType[]{leftType, rightType});
+    }
+
+    public String toString() {
+        GLSLOperator operator = getOperator();
+        if(operator == null){
+            return "Binary Operator: '(unknown)'";
+        }else{
+            return "Binary Operator: '" + operator.getTextRepresentation() + "'";
+        }
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLCondition.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLCondition.java
@@ -47,16 +47,16 @@ public class GLSLCondition extends GLSLElementImpl implements GLSLTypedElement {
         return null;
     }
 
-    public GLSLExpression getConditionExpression()
-    {
+    @Nullable
+    public GLSLExpression getConditionExpression() {
         GLSLDeclarator declarator = getDeclarator();
         if(declarator != null)
             return declarator.getInitializerExpression();
         return findChildByClass(GLSLExpression.class);
     }
-    
-    public GLSLVariableDeclaration getVariableDeclaration()
-    {
+
+    @Nullable
+    public GLSLVariableDeclaration getVariableDeclaration() {
         return findChildByClass(GLSLVariableDeclaration.class);
     }
 
@@ -69,7 +69,12 @@ public class GLSLCondition extends GLSLElementImpl implements GLSLTypedElement {
             if(typeSpecifier != null) return typeSpecifier.getType();
             else return GLSLTypes.UNKNOWN_TYPE;
         }
-        
-        return getConditionExpression().getType();
+
+        GLSLExpression conditionExpression = getConditionExpression();
+        if(conditionExpression == null){
+            return GLSLTypes.UNKNOWN_TYPE;
+        }else{
+            return conditionExpression.getType();
+        }
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLFunctionCallExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLFunctionCallExpression.java
@@ -145,7 +145,7 @@ public class GLSLFunctionCallExpression extends GLSLExpression implements GLSLRe
             } else if (current instanceof GLSLVariableDeclaration) {
                 GLSLVariableDeclaration declaration = (GLSLVariableDeclaration) current;
                 GLSLTypeSpecifier typeSpecifier = declaration.getTypeSpecifierNode();
-                GLSLType type = typeSpecifier.getType();
+                GLSLType type = typeSpecifier.getType();//TODO This may (and will) crash
                 if (getFunctionName().equals(type.getTypename())) {
                     for (GLSLFunctionType constructor : type.getConstructors()) {
                         switch (constructor.getParameterCompatibilityLevel(getParameterList().getParameterTypes())) {

--- a/src/glslplugin/lang/elements/expressions/GLSLFunctionCallExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLFunctionCallExpression.java
@@ -33,6 +33,7 @@ import glslplugin.lang.elements.types.GLSLFunctionType;
 import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLTypes;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,17 +50,33 @@ public class GLSLFunctionCallExpression extends GLSLExpression implements GLSLRe
         super(astNode);
     }
 
+    @Nullable
     public GLSLIdentifier getFunctionNameIdentifier() {
         final PsiElement first = getFirstChild();
-        return (GLSLIdentifier) first;
+        if(first instanceof GLSLIdentifier) return (GLSLIdentifier) first;
+        else return null;
     }
 
+    @NotNull
     public String getFunctionName() {
-        return getFunctionNameIdentifier().getIdentifierName();
+        GLSLIdentifier identifier = getFunctionNameIdentifier();
+        if(identifier != null){
+            return identifier.getIdentifierName();
+        }else{
+            return "(unknown)";
+        }
     }
 
+    @Nullable
     public GLSLParameterList getParameterList() {
         return findChildByClass(GLSLParameterList.class);
+    }
+
+    @NotNull
+    public GLSLType[] getParameterTypes(){
+        GLSLParameterList parameterList = getParameterList();
+        if(parameterList != null)return parameterList.getParameterTypes();
+        else return GLSLType.EMPTY_ARRAY;
     }
 
     @NotNull
@@ -73,6 +90,7 @@ public class GLSLFunctionCallExpression extends GLSLExpression implements GLSLRe
         }
     }
 
+    @Nullable
     public GLSLFunctionReference getReferenceProxy() {
         GLSLElement[] declarations = findFunctionDeclarations();
         if (declarations.length > 0) {
@@ -82,6 +100,7 @@ public class GLSLFunctionCallExpression extends GLSLExpression implements GLSLRe
         }
     }
 
+    @NotNull
     private GLSLElement[] findFunctionDeclarations() {
         GLSLFunctionType[] declarations = findFunctionTypes();
         List<GLSLElement> realDeclarations = new ArrayList<GLSLElement>();
@@ -95,6 +114,7 @@ public class GLSLFunctionCallExpression extends GLSLExpression implements GLSLRe
     }
 
     private final GLSLFunctionType[] NO_FUNCTION_TYPES = new GLSLFunctionType[0];
+    @NotNull
     public GLSLFunctionType[] findFunctionTypes() {
         List<GLSLFunctionType> compatibleDeclarations = new ArrayList<GLSLFunctionType>();
 
@@ -126,7 +146,8 @@ public class GLSLFunctionCallExpression extends GLSLExpression implements GLSLRe
                 functionType = function.getType();
 
                 if (getFunctionName().equals(functionType.getName())) {
-                    switch (functionType.getParameterCompatibilityLevel(getParameterList().getParameterTypes())) {
+
+                    switch (functionType.getParameterCompatibilityLevel(getParameterTypes())) {
                         case COMPATIBLE_WITH_IMPLICIT_CONVERSION:
                             compatibleDeclarations.add(functionType);
                             break;
@@ -145,22 +166,24 @@ public class GLSLFunctionCallExpression extends GLSLExpression implements GLSLRe
             } else if (current instanceof GLSLVariableDeclaration) {
                 GLSLVariableDeclaration declaration = (GLSLVariableDeclaration) current;
                 GLSLTypeSpecifier typeSpecifier = declaration.getTypeSpecifierNode();
-                GLSLType type = typeSpecifier.getType();//TODO This may (and will) crash
-                if (getFunctionName().equals(type.getTypename())) {
-                    for (GLSLFunctionType constructor : type.getConstructors()) {
-                        switch (constructor.getParameterCompatibilityLevel(getParameterList().getParameterTypes())) {
-                            case COMPATIBLE_WITH_IMPLICIT_CONVERSION:
-                                compatibleDeclarations.add(constructor);
-                                break;
+                if(typeSpecifier != null){
+                    GLSLType type = typeSpecifier.getType();
+                    if (getFunctionName().equals(type.getTypename())) {
+                        for (GLSLFunctionType constructor : type.getConstructors()) {
+                            switch (constructor.getParameterCompatibilityLevel(getParameterTypes())) {
+                                case COMPATIBLE_WITH_IMPLICIT_CONVERSION:
+                                    compatibleDeclarations.add(constructor);
+                                    break;
 
-                            case DIRECTLY_COMPATIBLE:
-                                return new GLSLFunctionType[]{constructor};
+                                case DIRECTLY_COMPATIBLE:
+                                    return new GLSLFunctionType[]{constructor};
 
-                            case INCOMPATIBLE:
-                                break;
+                                case INCOMPATIBLE:
+                                    break;
 
-                            default:
-                                assert false : "Unsupported compatibility level.";
+                                default:
+                                    assert false : "Unsupported compatibility level.";
+                            }
                         }
                     }
                 }

--- a/src/glslplugin/lang/elements/expressions/GLSLGroupedExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLGroupedExpression.java
@@ -21,7 +21,11 @@ package glslplugin.lang.elements.expressions;
 
 import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.types.GLSLType;
+import glslplugin.lang.elements.types.GLSLTypes;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLGroupedExpression is ...
@@ -35,19 +39,26 @@ public class GLSLGroupedExpression extends GLSLPrimaryExpression {
         super(astNode);
     }
 
+    @Nullable
     public GLSLExpression getExpression() {
         GLSLExpression expr = findChildByClass(GLSLExpression.class);
         if (expr != null) {
             return expr;
         } else {
-            throw new RuntimeException("Grouped expression does not contain any expression!");
+            Logger.getLogger("GLSLGroupedExpression").warning("Grouped expression does not contain any expression!");
+            return null;
         }
     }
 
     @NotNull
     @Override
     public GLSLType getType() {
-        return getExpression().getType();
+        GLSLExpression expression = getExpression();
+        if(expression != null){
+            return expression.getType();
+        }else{
+            return GLSLTypes.UNKNOWN_TYPE;
+        }
     }
 
     public String toString() {

--- a/src/glslplugin/lang/elements/expressions/GLSLIdentifierExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLIdentifierExpression.java
@@ -50,14 +50,18 @@ public class GLSLIdentifierExpression extends GLSLExpression implements GLSLRefe
         return true;
     }
 
+    @Nullable
     public GLSLIdentifier getIdentifier() {
-        GLSLIdentifier id = findChildByClass(GLSLIdentifier.class);
-        assert id != null;
-        return id;
+        return findChildByClass(GLSLIdentifier.class);
     }
 
     public String getIdentifierName() {
-        return getIdentifier().getIdentifierName();
+        GLSLIdentifier identifier = getIdentifier();
+        if(identifier != null){
+            return identifier.getIdentifierName();
+        }else{
+            return "(unknown)";
+        }
     }
 
     @Override
@@ -78,6 +82,7 @@ public class GLSLIdentifierExpression extends GLSLExpression implements GLSLRefe
         return GLSLTypes.UNKNOWN_TYPE;
     }
 
+    @Nullable
     public GLSLVariableReference getReferenceProxy() {
         GLSLDeclarator target = getVariableReference(this);
 

--- a/src/glslplugin/lang/elements/expressions/GLSLLiteral.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLLiteral.java
@@ -90,8 +90,13 @@ public class GLSLLiteral extends GLSLPrimaryExpression {
         }
     }
 
+    @NotNull
+    public String getLiteralValue(){
+        return getText();
+    }
+
     public String toString() {
         Type literalType = getLiteralType();
-        return (literalType == null ? "(unknown)" : getLiteralType().textRepresentation) + " Literal: '" + getText() + "'";
+        return (literalType == null ? "(unknown)" : getLiteralType().textRepresentation) + " Literal: '" + getLiteralValue() + "'";
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLLiteral.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLLiteral.java
@@ -25,6 +25,9 @@ import glslplugin.lang.elements.GLSLTokenTypes;
 import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLTypes;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLLiteral is ...
@@ -55,6 +58,7 @@ public class GLSLLiteral extends GLSLPrimaryExpression {
         super(astNode);
     }
 
+    @Nullable
     public Type getLiteralType() {
         IElementType type = getNode().getFirstChildNode().getElementType();
         if (type == GLSLTokenTypes.BOOL_CONSTANT) return Type.BOOL;
@@ -63,16 +67,23 @@ public class GLSLLiteral extends GLSLPrimaryExpression {
         if (type == GLSLTokenTypes.FLOAT_CONSTANT) return Type.FLOAT;
         if (type == GLSLTokenTypes.DOUBLE_CONSTANT) return Type.DOUBLE;
 
-        throw new RuntimeException("Unsupported literal type.");
-    }
-
-    public String toString() {
-        return getLiteralType().textRepresentation + " Literal: '" + getText() + "'";
+        Logger.getLogger("GLSLLiteral").warning("Unsupported literal type. ("+type+")");
+        return null;
     }
 
     @NotNull
     @Override
     public GLSLType getType() {
-        return getLiteralType().type;
+        Type literalType = getLiteralType();
+        if(literalType != null){
+            return literalType.type;
+        }else{
+            return GLSLTypes.UNKNOWN_TYPE;
+        }
+    }
+
+    public String toString() {
+        Type literalType = getLiteralType();
+        return (literalType == null ? "(unknown)" : getLiteralType().textRepresentation) + " Literal: '" + getText() + "'";
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLLiteral.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLLiteral.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
  *         Time: 1:50:35 PM
  */
 public class GLSLLiteral extends GLSLPrimaryExpression {
-    private enum Type {
+    public enum Type {
         BOOL("Bool", GLSLTypes.BOOL),
         FLOAT("Float", GLSLTypes.FLOAT),
         DOUBLE("Double", GLSLTypes.DOUBLE),
@@ -61,13 +61,21 @@ public class GLSLLiteral extends GLSLPrimaryExpression {
     @Nullable
     public Type getLiteralType() {
         IElementType type = getNode().getFirstChildNode().getElementType();
+
+        Type result = getLiteralType(type);
+        if(result != null)return result;
+
+        Logger.getLogger("GLSLLiteral").warning("Unsupported literal type. ("+type+")");
+        return null;
+    }
+
+    @Nullable
+    public static Type getLiteralType(IElementType type){
         if (type == GLSLTokenTypes.BOOL_CONSTANT) return Type.BOOL;
         if (type == GLSLTokenTypes.INTEGER_CONSTANT) return Type.INTEGER;
         if (type == GLSLTokenTypes.UINT_CONSTANT) return Type.UINT;
         if (type == GLSLTokenTypes.FLOAT_CONSTANT) return Type.FLOAT;
         if (type == GLSLTokenTypes.DOUBLE_CONSTANT) return Type.DOUBLE;
-
-        Logger.getLogger("GLSLLiteral").warning("Unsupported literal type. ("+type+")");
         return null;
     }
 

--- a/src/glslplugin/lang/elements/expressions/GLSLMethodCallExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLMethodCallExpression.java
@@ -19,12 +19,13 @@
 
 package glslplugin.lang.elements.expressions;
 
-import org.jetbrains.annotations.NotNull;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
-import glslplugin.lang.elements.expressions.GLSLSelectionExpressionBase;
-import glslplugin.lang.elements.expressions.GLSLParameterList;
 import glslplugin.lang.elements.GLSLIdentifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLMethodCall is ...
@@ -38,22 +39,35 @@ public class GLSLMethodCallExpression extends GLSLSelectionExpressionBase {
         super(astNode);
     }
 
+    @Nullable
     public GLSLIdentifier getMethodIdentifier() {
         GLSLIdentifier id = findChildByClass(GLSLIdentifier.class);
         if (id != null) {
             return id;
         } else {
-            throw new RuntimeException("Method call expression with no method identifier.");
+            Logger.getLogger("GLSLMethodCallExpression").warning("Method call expression with no method identifier.");
+            return null;
         }
     }
 
+    @NotNull
     public String getMethodName() {
-        return getMethodIdentifier().getIdentifierName();
+        GLSLIdentifier methodIdentifier = getMethodIdentifier();
+        if(methodIdentifier != null){
+            return methodIdentifier.getIdentifierName();
+        }else{
+            return "(unknown)";
+        }
     }
 
+    @Nullable
     public GLSLParameterList getParameterList() {
         final PsiElement last = getLastChild();
-        return (GLSLParameterList) last;
+        if(last instanceof GLSLParameterList){
+            return (GLSLParameterList) last;
+        }else{
+            return null;
+        }
     }
 
     @Override

--- a/src/glslplugin/lang/elements/expressions/GLSLOperatorExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLOperatorExpression.java
@@ -23,6 +23,9 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.elements.GLSLTokenTypes;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLOperatorExpression is the base class for all operator expressions.
@@ -37,20 +40,23 @@ public abstract class GLSLOperatorExpression extends GLSLExpression {
         super(astNode);
     }
 
+    @NotNull
     protected GLSLExpression[] getOperands() {
         return findChildrenByClass(GLSLExpression.class);
     }
 
+    @Nullable
     public GLSLOperator getOperator() {
         ASTNode operatorNode = getNode().findChildByType(GLSLTokenTypes.OPERATORS);
         if (operatorNode != null) {
             return getOperatorFromType(operatorNode.getElementType());
         } else {
-            throw new RuntimeException("Operator does not contain an operator token.");
+            Logger.getLogger("GLSLOperatorExpression").warning("Operator does not contain an operator token.");
+            return null;
         }
     }
 
-    @NotNull
+    @Nullable
     protected GLSLOperator getOperatorFromType(final IElementType type) {
         if (type == GLSLTokenTypes.INC_OP) return GLSLOperator.INCREMENT;
         if (type == GLSLTokenTypes.DEC_OP) return GLSLOperator.DECREMENT;
@@ -93,6 +99,7 @@ public abstract class GLSLOperatorExpression extends GLSLExpression {
 
         if (type == GLSLTokenTypes.DOT) return GLSLOperator.MEMBER;
 
-        throw new RuntimeException("Unsupported Operator: '" + getText() + "'");
+        Logger.getLogger("Unsupported Operator: '" + getText() + "'");
+        return null;
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLParameterList.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLParameterList.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * GLSLParameterList is ...
@@ -43,6 +44,7 @@ public class GLSLParameterList extends GLSLElementImpl implements Iterable<GLSLE
         super(astNode);
     }
 
+    @NotNull
     public GLSLExpression[] getParameters() {
         // convert the list of children to a list of GLSLStatement objects while performing sanity check.
         PsiElement[] children = getChildren();
@@ -55,7 +57,7 @@ public class GLSLParameterList extends GLSLElementImpl implements Iterable<GLSLE
                 if (node != null) {
                     final IElementType type = node.getElementType();
                     if (!GLSLTokenTypes.COMMENTS.contains(type)) {
-                        throw new RuntimeException("Parameter list contains non-comment, non-expression element.");
+                        Logger.getLogger("GLSLParameterList").warning("Parameter list contains non-comment, non-expression element.");
                     }
                 }
             }
@@ -63,6 +65,7 @@ public class GLSLParameterList extends GLSLElementImpl implements Iterable<GLSLE
         return result.toArray(new GLSLExpression[result.size()]);
     }
 
+    @NotNull
     public GLSLType[] getParameterTypes() {
         // convert the list of children to a list of GLSLStatement objects while performing sanity check.
         PsiElement[] children = getChildren();
@@ -75,7 +78,7 @@ public class GLSLParameterList extends GLSLElementImpl implements Iterable<GLSLE
                 if (node != null) {
                     final IElementType type = node.getElementType();
                     if (!GLSLTokenTypes.COMMENTS.contains(type)) {
-                        throw new RuntimeException("Parameter list contains non-comment, non-expression element.");
+                        Logger.getLogger("GLSLParameterList").warning("Parameter list contains non-comment, non-expression element.");
                     }
                 }
             }

--- a/src/glslplugin/lang/elements/expressions/GLSLPostfixExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLPostfixExpression.java
@@ -21,6 +21,9 @@ package glslplugin.lang.elements.expressions;
 
 import com.intellij.lang.ASTNode;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * PostfixOperator is ...
@@ -34,16 +37,23 @@ public class GLSLPostfixExpression extends GLSLOperatorExpression {
         super(astNode);
     }
 
+    @Nullable
     public GLSLExpression getOperand() {
         GLSLExpression[] operands = getOperands();
         if (operands.length != 1) {
             return operands[0];
         } else {
-            throw new RuntimeException("Postfix operator with " + operands.length + " operand(s).");
+            Logger.getLogger("GLSLPostfixExpression").warning("Postfix operator with " + operands.length + " operand(s).");
+            return null;
         }
     }
 
     public String toString() {
-        return "Postfix Operator '" + getOperator().getTextRepresentation() + "'";
+        GLSLOperator operator = getOperator();
+        if(operator != null){
+            return "Postfix Operator '" + operator.getTextRepresentation() + "'";
+        }else{
+            return "Postfix Operator '(unknown)'";
+        }
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLPrefixOperatorExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLPrefixOperatorExpression.java
@@ -22,6 +22,9 @@ package glslplugin.lang.elements.expressions;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * PostfixOperator is ...
@@ -35,12 +38,14 @@ public class GLSLPrefixOperatorExpression extends GLSLOperatorExpression {
         super(astNode);
     }
 
+    @Nullable
     public GLSLExpression getOperand() {
         GLSLExpression[] operands = getOperands();
         if (operands.length != 1) {
             return operands[0];
         } else {
-            throw new RuntimeException("Prefix operator with " + operands.length + " operand(s).");
+            Logger.getLogger("GLSLPrefixOperatorExpression").warning("Prefix operator with " + operands.length + " operand(s).");
+            return null;
         }
     }
 
@@ -51,6 +56,7 @@ public class GLSLPrefixOperatorExpression extends GLSLOperatorExpression {
      * @return the resulting operator.
      */
     @Override
+    @Nullable
     protected GLSLOperator getOperatorFromType(IElementType type) {
         GLSLOperator op = super.getOperatorFromType(type);
         if (op == GLSLOperator.ADDITION) op = GLSLOperator.PLUS;
@@ -59,6 +65,11 @@ public class GLSLPrefixOperatorExpression extends GLSLOperatorExpression {
     }
 
     public String toString() {
-        return "Prefix Operator '" + getOperator().getTextRepresentation() + "'";
+        GLSLOperator operator = getOperator();
+        if(operator != null){
+            return "Prefix Operator '" + operator.getTextRepresentation() + "'";
+        }else{
+            return "Prefix Operator '(unknown)'";
+        }
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLSelectionExpressionBase.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLSelectionExpressionBase.java
@@ -22,6 +22,9 @@ package glslplugin.lang.elements.expressions;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLSelectionExpressionBase is ...
@@ -35,12 +38,14 @@ public abstract class GLSLSelectionExpressionBase extends GLSLExpression {
         super(astNode);
     }
 
+    @Nullable
     public GLSLExpression getLeftHandExpression() {
         PsiElement first = getFirstChild();
         if (first instanceof GLSLExpression) {
             return (GLSLExpression) first;
         } else {
-            throw new RuntimeException("Field selection operator missing postfix expression in front of '.'");
+            Logger.getLogger("GLSLSelectionExpressionBase").warning("Field selection operator missing postfix expression in front of '.'");
+            return null;
         }
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLSubscriptExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLSubscriptExpression.java
@@ -23,6 +23,9 @@ import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.types.GLSLType;
 import glslplugin.lang.elements.types.GLSLTypes;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLSubscriptExpression is ...
@@ -36,27 +39,23 @@ public class GLSLSubscriptExpression extends GLSLOperatorExpression {
         super(node);
     }
 
+    @Nullable
     public GLSLExpression getArrayExpression() {
         GLSLExpression[] operands = getOperands();
         if (operands.length == 2) {
             return operands[0];
         } else {
-            throw new RuntimeException("Binary operator with " + operands.length + " operand(s).");
-        }
-    }
-
-    public GLSLExpression getSubscriptExpression() {
-        GLSLExpression[] operands = getOperands();
-        if (operands.length == 2) {
-            return operands[0];
-        } else {
-            throw new RuntimeException("Binary operator with " + operands.length + " operand(s).");
+            Logger.getLogger("GLSLSubscriptExpression").warning("Binary operator with " + operands.length + " operand(s).");
+            return null;
         }
     }
 
     @Override
     public boolean isLValue() {
-        return getArrayExpression().isLValue();
+        GLSLExpression arrExpr = getArrayExpression();
+        //noinspection SimplifiableIfStatement
+        if(arrExpr != null)return arrExpr.isLValue();
+        else return true;
     }
 
     @Override
@@ -68,6 +67,7 @@ public class GLSLSubscriptExpression extends GLSLOperatorExpression {
     @Override
     public GLSLType getType() {
         GLSLExpression left = getArrayExpression();
+        if(left == null)return GLSLTypes.UNKNOWN_TYPE;
         GLSLType type = left.getType();
         if (type != GLSLTypes.UNKNOWN_TYPE) {
             if (type.isIndexable()) {

--- a/src/glslplugin/lang/elements/preprocessor/GLSLElementDropIn.java
+++ b/src/glslplugin/lang/elements/preprocessor/GLSLElementDropIn.java
@@ -19,34 +19,17 @@
 
 package glslplugin.lang.elements.preprocessor;
 
-import com.intellij.lang.ASTNode;
-import glslplugin.lang.elements.expressions.GLSLExpression;
-import glslplugin.lang.elements.types.GLSLType;
-import glslplugin.lang.elements.types.GLSLTypes;
+import glslplugin.lang.elements.GLSLElement;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Darkyen
  */
-public class GLSLExpressionDropIn extends GLSLExpression implements GLSLElementDropIn {
-    public GLSLExpressionDropIn(@NotNull ASTNode astNode) {
-        super(astNode);
-    }
+public interface GLSLElementDropIn extends GLSLElement {
 
-    @Override
-    public boolean isLValue() {
-        return false;
-    }
-
+    /**
+     * @return text which this element emulates
+     */
     @NotNull
-    @Override
-    public GLSLType getType() {
-        return GLSLTypes.UNKNOWN_TYPE;
-    }
-
-    @NotNull
-    @Override
-    public String getOriginalText() {
-        return "TBD";//TODO Get and present real value
-    }
+    String getOriginalText();
 }

--- a/src/glslplugin/lang/elements/preprocessor/GLSLEmptyDropIn.java
+++ b/src/glslplugin/lang/elements/preprocessor/GLSLEmptyDropIn.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010 Jean-Paul Balabanian and Yngve Devik Hammersland
+ *
+ *     This file is part of glsl4idea.
+ *
+ *     Glsl4idea is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as
+ *     published by the Free Software Foundation, either version 3 of
+ *     the License, or (at your option) any later version.
+ *
+ *     Glsl4idea is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package glslplugin.lang.elements.preprocessor;
+
+import com.intellij.lang.ASTNode;
+import glslplugin.lang.elements.GLSLElementImpl;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Darkyen
+ */
+public class GLSLEmptyDropIn extends GLSLElementImpl implements GLSLElementDropIn {
+    public GLSLEmptyDropIn(@NotNull ASTNode astNode) {
+        super(astNode);
+    }
+
+    @NotNull
+    @Override
+    public String getOriginalText() {
+        return "(empty)";
+    }
+}

--- a/src/glslplugin/lang/elements/preprocessor/GLSLExpressionDropIn.java
+++ b/src/glslplugin/lang/elements/preprocessor/GLSLExpressionDropIn.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2010 Jean-Paul Balabanian and Yngve Devik Hammersland
+ *
+ *     This file is part of glsl4idea.
+ *
+ *     Glsl4idea is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as
+ *     published by the Free Software Foundation, either version 3 of
+ *     the License, or (at your option) any later version.
+ *
+ *     Glsl4idea is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package glslplugin.lang.elements.preprocessor;
+
+import com.intellij.lang.ASTNode;
+import glslplugin.lang.elements.expressions.GLSLExpression;
+import glslplugin.lang.elements.types.GLSLType;
+import glslplugin.lang.elements.types.GLSLTypes;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Darkyen
+ */
+public class GLSLExpressionDropIn extends GLSLExpression {
+    public GLSLExpressionDropIn(@NotNull ASTNode astNode) {
+        super(astNode);
+    }
+
+    @Override
+    public boolean isLValue() {
+        return false;
+    }
+
+    @NotNull
+    @Override
+    public GLSLType getType() {
+        return GLSLTypes.UNKNOWN_TYPE;
+    }
+}

--- a/src/glslplugin/lang/elements/preprocessor/GLSLExpressionDropIn.java
+++ b/src/glslplugin/lang/elements/preprocessor/GLSLExpressionDropIn.java
@@ -29,8 +29,12 @@ import org.jetbrains.annotations.NotNull;
  * @author Darkyen
  */
 public class GLSLExpressionDropIn extends GLSLExpression implements GLSLElementDropIn {
-    public GLSLExpressionDropIn(@NotNull ASTNode astNode) {
+
+    private final String originalText;
+
+    public GLSLExpressionDropIn(@NotNull ASTNode astNode, @NotNull String originalText) {
         super(astNode);
+        this.originalText = originalText;
     }
 
     @Override
@@ -47,6 +51,6 @@ public class GLSLExpressionDropIn extends GLSLExpression implements GLSLElementD
     @NotNull
     @Override
     public String getOriginalText() {
-        return "TBD";//TODO Get and present real value
+        return originalText;
     }
 }

--- a/src/glslplugin/lang/elements/preprocessor/GLSLLiteralDropIn.java
+++ b/src/glslplugin/lang/elements/preprocessor/GLSLLiteralDropIn.java
@@ -17,19 +17,36 @@
  *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package glslplugin.lang.parser;
+package glslplugin.lang.elements.preprocessor;
 
-import com.intellij.psi.tree.IElementType;
+import com.intellij.lang.ASTNode;
+import glslplugin.lang.elements.expressions.GLSLLiteral;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Darkyen
  */
-public class PreprocessorToken {
-    public final IElementType type;
-    public final String text;
+public class GLSLLiteralDropIn extends GLSLLiteral {
 
-    public PreprocessorToken(IElementType type, CharSequence text) {
+    private Type type;
+    private String text;
+
+    public GLSLLiteralDropIn(@NotNull ASTNode astNode, @NotNull Type type, @NotNull String text) {
+        super(astNode);
         this.type = type;
-        this.text = text.toString();
+        this.text = text;
+    }
+
+    @Nullable
+    @Override
+    public Type getLiteralType() {
+        return type;
+    }
+
+    @NotNull
+    @Override
+    public String getLiteralValue() {
+        return text;
     }
 }

--- a/src/glslplugin/lang/elements/preprocessor/GLSLLiteralDropIn.java
+++ b/src/glslplugin/lang/elements/preprocessor/GLSLLiteralDropIn.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Darkyen
  */
-public class GLSLLiteralDropIn extends GLSLLiteral {
+public class GLSLLiteralDropIn extends GLSLLiteral implements GLSLElementDropIn {
 
     private Type type;
     private String text;
@@ -47,6 +47,12 @@ public class GLSLLiteralDropIn extends GLSLLiteral {
     @NotNull
     @Override
     public String getLiteralValue() {
+        return text;
+    }
+
+    @NotNull
+    @Override
+    public String getOriginalText() {
         return text;
     }
 }

--- a/src/glslplugin/lang/elements/preprocessor/GLSLUnknownDropIn.java
+++ b/src/glslplugin/lang/elements/preprocessor/GLSLUnknownDropIn.java
@@ -17,32 +17,27 @@
  *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package glslplugin.lang.parser;
+package glslplugin.lang.elements.preprocessor;
 
-import com.intellij.psi.tree.IElementType;
-import glslplugin.lang.GLSLLanguage;
-
-import java.util.List;
+import com.intellij.lang.ASTNode;
+import glslplugin.lang.elements.GLSLElementImpl;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Darkyen
  */
-public final class GLSLRedefinedTokenType extends IElementType {
+public class GLSLUnknownDropIn extends GLSLElementImpl implements GLSLElementDropIn {
 
-    public final List<PreprocessorToken> redefinedTo;
-    private boolean marked = false;
+    private final String text;
 
-    protected GLSLRedefinedTokenType(List<PreprocessorToken> redefinedTo) {
-        super("GLSLRedefinedTokenType", GLSLLanguage.GLSL_LANGUAGE, false);
-        this.redefinedTo = redefinedTo;
+    public GLSLUnknownDropIn(@NotNull ASTNode astNode, @NotNull String text) {
+        super(astNode);
+        this.text = text;
     }
 
-    public boolean mark(){
-        if(!marked){
-            marked = true;
-            return true;
-        }else{
-            return false;
-        }
+    @NotNull
+    @Override
+    public String getOriginalText() {
+        return text;
     }
 }

--- a/src/glslplugin/lang/elements/statements/GLSLBreakStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLBreakStatement.java
@@ -35,8 +35,6 @@ public class GLSLBreakStatement extends GLSLStatement {
         super(astNode);
     }
 
-    // TODO: Implement
-
     @Override
     public String toString() {
         return "Break Statement";

--- a/src/glslplugin/lang/elements/statements/GLSLCompoundStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLCompoundStatement.java
@@ -20,14 +20,8 @@
 package glslplugin.lang.elements.statements;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
-import glslplugin.lang.elements.GLSLTokenTypes;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * GLSLCompoundStatement is ...

--- a/src/glslplugin/lang/elements/statements/GLSLCompoundStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLCompoundStatement.java
@@ -44,7 +44,7 @@ public class GLSLCompoundStatement extends GLSLStatement {
     @NotNull
     public GLSLStatement[] getStatements() {
         GLSLStatement[] statements = PsiTreeUtil.getChildrenOfType(this, GLSLStatement.class);
-        return (statements == null) ? new GLSLStatement[0] : statements;
+        return (statements == null) ? GLSLStatement.NO_STATEMENTS : statements;
     }
 
     public String toString() {

--- a/src/glslplugin/lang/elements/statements/GLSLContinueStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLContinueStatement.java
@@ -35,8 +35,6 @@ public class GLSLContinueStatement extends GLSLStatement {
         super(astNode);
     }
 
-    // TODO: Implement
-
     @Override
     public String toString() {
         return "Continue Statement";

--- a/src/glslplugin/lang/elements/statements/GLSLDeclarationStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLDeclarationStatement.java
@@ -19,9 +19,11 @@
 
 package glslplugin.lang.elements.statements;
 
+import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.declarations.GLSLVariableDeclaration;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * GLSLDeclarationStatement is ...
@@ -35,8 +37,14 @@ public class GLSLDeclarationStatement extends GLSLStatement {
         super(astNode);
     }
 
+    @Nullable
     public GLSLVariableDeclaration getDeclaration() {
-        return (GLSLVariableDeclaration) getFirstChild();
+        PsiElement firstChild = getFirstChild();
+        if(firstChild instanceof GLSLVariableDeclaration){
+            return (GLSLVariableDeclaration) getFirstChild();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/src/glslplugin/lang/elements/statements/GLSLDiscardStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLDiscardStatement.java
@@ -34,8 +34,6 @@ public class GLSLDiscardStatement extends GLSLStatement {
         super(astNode);
     }
 
-    // TODO: Implement
-
     @Override
     public String toString() {
         return "Discard Statement";

--- a/src/glslplugin/lang/elements/statements/GLSLDoStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLDoStatement.java
@@ -23,6 +23,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import glslplugin.lang.elements.expressions.GLSLCondition;
 import org.jetbrains.annotations.NotNull;
 import com.intellij.lang.ASTNode;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * GLSLDeclarationStatement is ...
@@ -36,13 +37,10 @@ public class GLSLDoStatement extends GLSLStatement implements ConditionStatement
         super(astNode);
     }
 
+    @Nullable
     public GLSLCondition getCondition() {
-        GLSLCondition condition = findChildByClass(GLSLCondition.class);
-        assert condition != null;
-        return condition;
+        return findChildByClass(GLSLCondition.class);
     }
-
-    // TODO: Implement
 
     @Override
     public String toString() {

--- a/src/glslplugin/lang/elements/statements/GLSLExpressionStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLExpressionStatement.java
@@ -22,6 +22,9 @@ package glslplugin.lang.elements.statements;
 import org.jetbrains.annotations.NotNull;
 import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.expressions.GLSLExpression;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Logger;
 
 /**
  * GLSLExpressionStatement is ...
@@ -35,12 +38,14 @@ public class GLSLExpressionStatement extends GLSLStatement {
         super(astNode);
     }
 
+    @Nullable
     public GLSLExpression getExpression() {
         GLSLExpression expr = findChildByClass(GLSLExpression.class);
         if (expr != null) {
             return expr;
         } else {
-            throw new RuntimeException("Expression statement with no expression!");
+            Logger.getLogger("GLSLExpressionStatement").warning("Expression statement with no expression!");
+            return null;
         }
     }
 

--- a/src/glslplugin/lang/elements/statements/GLSLForStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLForStatement.java
@@ -27,6 +27,7 @@ import glslplugin.lang.elements.declarations.GLSLDeclaration;
 import glslplugin.lang.elements.expressions.GLSLCondition;
 import glslplugin.lang.elements.expressions.GLSLExpression;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * GLSLDeclarationStatement is ...
@@ -77,8 +78,12 @@ public class GLSLForStatement extends GLSLStatement implements ConditionStatemen
      *
      * @return the loop initialization element.
      */
+    @Nullable
     public GLSLElement getInitializerElement() {
-        return getForElements()[0];
+        GLSLElement[] forElements = getForElements();
+        if(forElements.length > 0){
+            return forElements[0];
+        }else return null;
     }
 
     /**
@@ -87,8 +92,12 @@ public class GLSLForStatement extends GLSLStatement implements ConditionStatemen
      *
      * @return the loop condition element.
      */
+    @Nullable
     public GLSLCondition getCondition() {
-        return (GLSLCondition) getForElements()[1];
+        GLSLElement[] forElements = getForElements();
+        if(forElements.length > 1 && forElements[1] instanceof GLSLCondition){
+            return (GLSLCondition) forElements[1];
+        }else return null;
     }
 
     /**
@@ -97,15 +106,17 @@ public class GLSLForStatement extends GLSLStatement implements ConditionStatemen
      *
      * @return the loop counter expression.
      */
+    @Nullable
     public GLSLExpression getCountExpression() {
-        return (GLSLExpression) getForElements()[2];
+        GLSLElement[] forElements = getForElements();
+        if(forElements.length > 2 && forElements[2] instanceof GLSLExpression){
+            return (GLSLExpression) forElements[2];
+        }else return null;
     }
 
-
+    @Nullable
     public GLSLStatement getLoopStatement() {
-        GLSLStatement statement = findChildByClass(GLSLStatement.class);
-        assert statement != null;
-        return statement;
+        return findChildByClass(GLSLStatement.class);
     }
 
 
@@ -115,4 +126,5 @@ public class GLSLForStatement extends GLSLStatement implements ConditionStatemen
     }
 
     // TODO some for statements can be terminating if their condition can be constant-analyzed as true
+    // and don't contain any sort of break out. But that should probably be an error.
 }

--- a/src/glslplugin/lang/elements/statements/GLSLReturnStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLReturnStatement.java
@@ -38,13 +38,12 @@ public class GLSLReturnStatement extends GLSLStatement {
         super(astNode);
     }
 
-    // TODO: Implement
-
     @Override
     public String toString() {
         return "Return Statement";
     }
 
+    @NotNull
     public GLSLType getReturnType() {
         GLSLExpression child = findChildByClass(GLSLExpression.class);
         if (child != null) {

--- a/src/glslplugin/lang/elements/statements/GLSLStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLStatement.java
@@ -32,6 +32,9 @@ import org.jetbrains.annotations.NotNull;
  *         Time: 5:53:03 PM
  */
 public abstract class GLSLStatement extends GLSLElementImpl {
+
+    public static final GLSLStatement[] NO_STATEMENTS = new GLSLStatement[0];
+
     public GLSLStatement(@NotNull ASTNode astNode) {
         super(astNode);
     }

--- a/src/glslplugin/lang/elements/statements/GLSLStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLStatement.java
@@ -20,7 +20,6 @@
 package glslplugin.lang.elements.statements;
 
 import com.intellij.lang.ASTNode;
-import glslplugin.annotation.impl.UnreachableAnnotation;
 import glslplugin.lang.elements.GLSLElementImpl;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/glslplugin/lang/elements/statements/GLSLWhileStatement.java
+++ b/src/glslplugin/lang/elements/statements/GLSLWhileStatement.java
@@ -22,6 +22,7 @@ package glslplugin.lang.elements.statements;
 import com.intellij.lang.ASTNode;
 import glslplugin.lang.elements.expressions.GLSLCondition;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * GLSLDeclarationStatement is ...
@@ -35,14 +36,14 @@ public class GLSLWhileStatement extends GLSLStatement implements ConditionStatem
         super(astNode);
     }
 
+    @Nullable
     public GLSLCondition getCondition() {
         return findChildByClass(GLSLCondition.class);
     }
-    
-    GLSLStatement getLoopStatement() {
-        GLSLStatement loop = findChildByClass(GLSLStatement.class);
-        assert loop != null;
-        return loop;
+
+    @Nullable
+    public GLSLStatement getLoopStatement() {
+        return findChildByClass(GLSLStatement.class);
     }
 
     @Override

--- a/src/glslplugin/lang/elements/types/GLSLArrayType.java
+++ b/src/glslplugin/lang/elements/types/GLSLArrayType.java
@@ -21,6 +21,7 @@ package glslplugin.lang.elements.types;
 
 import glslplugin.lang.elements.declarations.GLSLArraySpecifier;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,7 @@ public class GLSLArrayType extends GLSLType {
     private GLSLArraySpecifier arraySpecifier;
     private Map<String, GLSLFunctionType> methods = new HashMap<String, GLSLFunctionType>();
 
-    public GLSLArrayType(@NotNull GLSLType baseType, GLSLArraySpecifier arraySpecifier) {
+    public GLSLArrayType(@NotNull GLSLType baseType, @Nullable GLSLArraySpecifier arraySpecifier) {
         this.baseType = baseType;
         this.arraySpecifier = arraySpecifier;
         this.methods.put("length", new GLSLBasicFunctionType("length", baseType));
@@ -55,11 +56,13 @@ public class GLSLArrayType extends GLSLType {
     }
 
     @Override
+    @Nullable
     public GLSLArraySpecifier getArraySpecifier() {
         return arraySpecifier;
     }
 
     @Override
+    @NotNull
     public Map<String, GLSLFunctionType> getMethods() {
         return methods;
     }

--- a/src/glslplugin/lang/elements/types/GLSLFunctionType.java
+++ b/src/glslplugin/lang/elements/types/GLSLFunctionType.java
@@ -34,6 +34,7 @@ import java.util.List;
  */
 public abstract class GLSLFunctionType extends GLSLType {
     public static final GLSLFunctionType[] EMPTY_ARRAY = {};
+
     protected final GLSLType returnType;
     protected String typename;
     @NotNull

--- a/src/glslplugin/lang/elements/types/GLSLFunctionType.java
+++ b/src/glslplugin/lang/elements/types/GLSLFunctionType.java
@@ -53,6 +53,7 @@ public abstract class GLSLFunctionType extends GLSLType {
 
     protected abstract String generateTypename();
 
+    @NotNull
     public String getTypename() {
         if (typename == null) {
             typename = generateTypename();
@@ -64,6 +65,7 @@ public abstract class GLSLFunctionType extends GLSLType {
      * @return The return type of the function.
      */
     @Override
+    @NotNull
     public GLSLType getBaseType() {
         return returnType;
     }

--- a/src/glslplugin/lang/elements/types/GLSLMatrixType.java
+++ b/src/glslplugin/lang/elements/types/GLSLMatrixType.java
@@ -139,12 +139,14 @@ public class GLSLMatrixType extends GLSLType {
     }
 
     @Override
+    @NotNull
     public String getTypename() {
         String prefix = PREFIXES.get(fundamentalType);
         if (prefix == null) prefix = "mat";
         return prefix + numColumns + "x" + numRows;
     }
 
+    @NotNull
     @Override
     public GLSLType getBaseType() {
         return GLSLVectorType.getType(numColumns, GLSLPrimitiveType.FLOAT);

--- a/src/glslplugin/lang/elements/types/GLSLMatrixType.java
+++ b/src/glslplugin/lang/elements/types/GLSLMatrixType.java
@@ -154,6 +154,7 @@ public class GLSLMatrixType extends GLSLType {
         return numColumns * numRows;
     }
 
+    @NotNull
     @Override
     public GLSLFunctionType[] getConstructors() {
         return new GLSLFunctionType[]{

--- a/src/glslplugin/lang/elements/types/GLSLPrimitiveType.java
+++ b/src/glslplugin/lang/elements/types/GLSLPrimitiveType.java
@@ -19,6 +19,8 @@
 
 package glslplugin.lang.elements.types;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -57,6 +59,7 @@ public class GLSLPrimitiveType extends GLSLType {
         this.implicitConversions = Arrays.asList(implicitConversions);
     }
 
+    @NotNull
     public String getTypename() {
         return typename;
     }

--- a/src/glslplugin/lang/elements/types/GLSLStructType.java
+++ b/src/glslplugin/lang/elements/types/GLSLStructType.java
@@ -56,6 +56,7 @@ public class GLSLStructType extends GLSLType {
         }
     }
 
+    @NotNull
     public String getTypename() {
         return typename;
     }

--- a/src/glslplugin/lang/elements/types/GLSLStructType.java
+++ b/src/glslplugin/lang/elements/types/GLSLStructType.java
@@ -21,6 +21,7 @@ package glslplugin.lang.elements.types;
 
 import glslplugin.lang.elements.declarations.GLSLDeclarator;
 import glslplugin.lang.elements.declarations.GLSLTypeDefinition;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -79,11 +80,13 @@ public class GLSLStructType extends GLSLType {
 
     }
 
+    @NotNull
     @Override
     public Map<String, GLSLType> getMembers() {
         return members;
     }
 
+    @NotNull
     @Override
     public GLSLType[] getMemberTypes() {
         return memberTypes;
@@ -94,6 +97,7 @@ public class GLSLStructType extends GLSLType {
         return true;
     }
 
+    @NotNull
     @Override
     public GLSLFunctionType[] getConstructors() {
         return new GLSLFunctionType[]{

--- a/src/glslplugin/lang/elements/types/GLSLType.java
+++ b/src/glslplugin/lang/elements/types/GLSLType.java
@@ -21,6 +21,8 @@ package glslplugin.lang.elements.types;
 
 import glslplugin.lang.elements.GLSLElement;
 import glslplugin.lang.elements.declarations.GLSLArraySpecifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +44,7 @@ public abstract class GLSLType {
     /**
      * @return the text representation of this type.
      */
+    @NotNull
     public abstract String getTypename();
 
     /**
@@ -49,6 +52,7 @@ public abstract class GLSLType {
      *
      * @return the array specifier, null if it is not present.
      */
+    @Nullable
     public GLSLArraySpecifier getArraySpecifier() {
         return null;
     }
@@ -67,6 +71,7 @@ public abstract class GLSLType {
      *
      * @return the type this type is based on, null if this is a primitive type or a struct.
      */
+    @NotNull
     public GLSLType getBaseType() {
         return GLSLTypes.INVALID_TYPE;
     }
@@ -78,6 +83,7 @@ public abstract class GLSLType {
      *
      * @return the definition of this type.
      */
+    @Nullable
     public GLSLElement getDefinition() {
         return null;
     }
@@ -108,14 +114,17 @@ public abstract class GLSLType {
     /**
      * @return a set containing all the names of the members of this type.
      */
+    @NotNull
     public Set<String> getMemberNames() {
         return getMembers().keySet();
     }
 
+    @NotNull
     public Map<String, GLSLType> getMembers() {
         return EMPTY_MEMBER_MAP;
     }
 
+    @NotNull
     public GLSLType[] getMemberTypes() {
         return GLSLType.EMPTY_ARRAY;
     }
@@ -134,8 +143,9 @@ public abstract class GLSLType {
      * Fetches the type of the member of the specified name.
      *
      * @param name the name to get the type of.
-     * @return the type if found, null otherwise.
+     * @return the type if found, {@link GLSLTypes#INVALID_TYPE} otherwise.
      */
+    @NotNull
     public GLSLType getTypeOfMember(String name) {
         if (getMembers().containsKey(name)) {
             return getMembers().get(name);
@@ -158,6 +168,7 @@ public abstract class GLSLType {
      *
      * @return an array containing all the constructors of this type.
      */
+    @NotNull
     public GLSLFunctionType[] getConstructors() {
         // All types has a type constructor which takes itself as an argument.
         return new GLSLFunctionType[]{new GLSLBasicFunctionType(getTypename(), this, this)};
@@ -168,6 +179,7 @@ public abstract class GLSLType {
      *
      * @return an array containing all the methods of this
      */
+    @NotNull
     public Map<String, GLSLFunctionType> getMethods() {
         return EMPTY_METHOD_MAP;
     }

--- a/src/glslplugin/lang/elements/types/GLSLTypes.java
+++ b/src/glslplugin/lang/elements/types/GLSLTypes.java
@@ -19,6 +19,8 @@
 
 package glslplugin.lang.elements.types;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -95,6 +97,7 @@ public class GLSLTypes {
     public static final GLSLPrimitiveType VOID = GLSLPrimitiveType.VOID;
 
     public static final GLSLType UNKNOWN_TYPE = new GLSLType() {
+        @NotNull
         public String getTypename() {
             return "(unknown type)";
         }
@@ -115,6 +118,7 @@ public class GLSLTypes {
         }
     };
     public static final GLSLType INVALID_TYPE = new GLSLType() {
+        @NotNull
         public String getTypename() {
             return "(invalid type)";
         }
@@ -143,6 +147,7 @@ public class GLSLTypes {
                     new GLSLType() {
                         private final String name = text;
 
+                        @NotNull
                         public String getTypename() {
                             return name;
                         }

--- a/src/glslplugin/lang/elements/types/GLSLVectorType.java
+++ b/src/glslplugin/lang/elements/types/GLSLVectorType.java
@@ -250,6 +250,7 @@ public class GLSLVectorType extends GLSLType {
         return null;
     }
 
+    @NotNull
     @Override
     public Map<String, GLSLType> getMembers() {
         return members;
@@ -260,6 +261,7 @@ public class GLSLVectorType extends GLSLType {
         return true;
     }
 
+    @NotNull
     @Override
     public GLSLFunctionType[] getConstructors() {
         return new GLSLFunctionType[]{

--- a/src/glslplugin/lang/elements/types/GLSLVectorType.java
+++ b/src/glslplugin/lang/elements/types/GLSLVectorType.java
@@ -235,11 +235,13 @@ public class GLSLVectorType extends GLSLType {
         this.constructor = new Constructor();
     }
 
+    @NotNull
     @Override
     public String getTypename() {
         return baseType.name + numComponents;
     }
 
+    @NotNull
     @Override
     public GLSLType getBaseType() {
         return baseType.type;

--- a/src/glslplugin/lang/parser/GLSLParser.java
+++ b/src/glslplugin/lang/parser/GLSLParser.java
@@ -25,10 +25,22 @@ import com.intellij.lang.PsiParser;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.Semaphore;
+
 public class GLSLParser implements PsiParser {
+
+    private static final boolean ALLOW_ONLY_ONE_THREAD = false;
+    private static final Semaphore SEMAPHORE = new Semaphore(1);
 
     @NotNull
     public ASTNode parse(IElementType root, PsiBuilder builder) {
+        if(ALLOW_ONLY_ONE_THREAD){
+            try {
+                SEMAPHORE.acquire();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
         //builder.setDebugMode(true);
         final PsiBuilder.Marker rootMarker = builder.mark();
         if(!builder.eof()){ //Empty file is not an error
@@ -40,6 +52,10 @@ public class GLSLParser implements PsiParser {
         }
 
         rootMarker.done(root);
+
+        if(ALLOW_ONLY_ONE_THREAD){
+            SEMAPHORE.release();
+        }
         return builder.getTreeBuilt();
     }
 }

--- a/src/glslplugin/lang/parser/GLSLParsing.java
+++ b/src/glslplugin/lang/parser/GLSLParsing.java
@@ -97,7 +97,7 @@ public final class GLSLParsing extends GLSLParsingBase {
 
                     PsiBuilder.Marker defineMeaningMark = mark();
 
-                    if(CONSTANT_TOKENS.contains(tokenType()) && lookAhead(1) == PREPROCESSOR_END){
+                    if(CONSTANT_TOKENS.contains(tokenType()) && lookAhead() == PREPROCESSOR_END){
                         meaning = PreprocessorDropInType.LITERAL;
                     }
 
@@ -265,7 +265,7 @@ public final class GLSLParsing extends GLSLParsingBase {
 
         parseQualifierList(true);
 
-        if (tokenType() == IDENTIFIER && lookAhead(1) == LEFT_BRACE) { // interface block
+        if (tokenType() == IDENTIFIER && lookAhead() == LEFT_BRACE) { // interface block
             //TODO Make sure that this is preceded by storage_qualifier
             parseIdentifier();
             match(LEFT_BRACE, "Expected '{'");

--- a/src/glslplugin/lang/parser/GLSLParsing.java
+++ b/src/glslplugin/lang/parser/GLSLParsing.java
@@ -301,10 +301,10 @@ public final class GLSLParsing {
                 psiBuilder.error("Identifier expected.");
                 //Eat rest
                 while (!isEof()) {
-                    psiBuilder.advanceLexer();
                     if (psiBuilder.getTokenType() == PREPROCESSOR_END) {
                         break;
                     }
+                    psiBuilder.advanceLexer();
                 }
             }
         }else if(psiBuilder.getTokenType() == PREPROCESSOR_UNDEF){
@@ -315,26 +315,28 @@ public final class GLSLParsing {
                 //Valid
                 final String defineIdentifier = psiBuilder.getTokenText();
                 defines.remove(defineIdentifier);
+
+                psiBuilder.advanceLexer();//Get past IDENTIFIER
             }else{
                 //Invalid
                 psiBuilder.error("Identifier expected.");
             }
             //Eat rest
             while (!isEof()) {
-                psiBuilder.advanceLexer();
                 if (psiBuilder.getTokenType() == PREPROCESSOR_END) {
                     break;
                 }else{
                     psiBuilder.error("Unexpected token.");
                 }
+                psiBuilder.advanceLexer();
             }
         }else{
             //Some other directive, no work here
             while (!isEof()) {
-                psiBuilder.advanceLexer();
                 if (psiBuilder.getTokenType() == PREPROCESSOR_END) {
                     break;
                 }
+                psiBuilder.advanceLexer();
             }
         }
         advanceLexer();//Get past PREPROCESSOR_END

--- a/src/glslplugin/lang/parser/GLSLParsing.java
+++ b/src/glslplugin/lang/parser/GLSLParsing.java
@@ -23,6 +23,8 @@ import com.intellij.lang.PsiBuilder;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 import glslplugin.lang.elements.GLSLTokenTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static glslplugin.lang.elements.GLSLElementTypes.*;
 import static glslplugin.lang.elements.GLSLTokenTypes.*;
@@ -56,11 +58,102 @@ public final class GLSLParsing {
     };
 
 
-    /* The source of operatorTokens and the target for the AST nodes. */
-    private final PsiBuilder b;
+    /** The source of operatorTokens and the target for the AST nodes.
+     * Do not use directly, use specialized proxy functions below, which can handle preprocessor
+     * directives and macro replacements.
+     * */
+    private final PsiBuilder psiBuilder;
 
     GLSLParsing(PsiBuilder builder) {
-        b = builder;
+        psiBuilder = builder;
+    }
+
+    //Code that deals with preprocessor, b.call replacements
+
+    //  b.call replacements that deal with defines
+
+    /**
+     * @return type of token lexer is at or null if eof
+     */
+    @Nullable
+    private IElementType tokenType() {
+        return psiBuilder.getTokenType();
+    }
+
+    /**
+     * @return type of token after [amount] times calling advanceLexer()
+     */
+    @Nullable
+    private IElementType lookAhead(int amount) {
+        return psiBuilder.lookAhead(amount);
+    }
+
+    /**
+     * Places a mark at token.
+     * This mark MUST be closed by calling functions on it,
+     * for example done() to complete the element,
+     * error() to mark element as invalid (error on the mark, not {@link GLSLParsing#error(String)}!)
+     * or drop() to cancel the mark altogether.
+     * @return placed mark
+     */
+    @NotNull
+    private PsiBuilder.Marker mark() {
+        return psiBuilder.mark();
+    }
+
+    /**
+     * Places an error at current lexer position.
+     * @param error message to be shown
+     */
+    private void error(String error) {
+        psiBuilder.error(error);
+    }
+
+    /**
+     * Returns same as eof(), but does not complain about anything
+     * and doesn't close anything.
+     * @return whether or not is the lexer at the end of the file
+     */
+    private boolean isEof() {
+        return psiBuilder.eof();
+    }
+
+    /**
+     * @return the text of current token
+     */
+    @Nullable
+    private String getTokenText() {
+        return psiBuilder.getTokenText();
+    }
+
+    private void advanceLexer() {
+        psiBuilder.advanceLexer();
+        if (tokenType() == PREPROCESSOR_BEGIN) {
+            parsePreprocessor();
+        }
+    }
+
+    //Utility code
+
+    /**
+     * Checks whether lexer is at the end of the file,
+     * complains about it if it is
+     * and closes all marks supplied (if eof).
+     * @return psiBuilder.eof()
+     */
+    private boolean eof(PsiBuilder.Marker... marksToClose) {
+        if (isEof()) {
+            if (marksToClose.length > 0) {
+                for (PsiBuilder.Marker mark : marksToClose) {
+                    mark.error("Premature end of file.");
+                }
+            } else {
+                error("Premature end of file.");
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -71,14 +164,14 @@ public final class GLSLParsing {
      * @return indicates whether the match was successful or not.
      */
     private boolean match(IElementType type, String error) {
-        if (b.eof()) {
+        if (isEof()) {
             return false;
         }
-        boolean match = b.getTokenType() == type;
+        boolean match = tokenType() == type;
         if (match) {
             advanceLexer();
         } else {
-            b.error(error);
+            error(error);
         }
         return match;
     }
@@ -90,12 +183,12 @@ public final class GLSLParsing {
      * @return indicates whether the match was successful or not.
      */
     private boolean tryMatch(IElementType... types) {
-        if (b.eof()) {
+        if (isEof()) {
             return false;
         }
         boolean match = false;
         for (IElementType type : types) {
-            match |= b.getTokenType() == type;
+            match |= tokenType() == type;
         }
         if (match) {
             advanceLexer();
@@ -110,34 +203,36 @@ public final class GLSLParsing {
      * @return indicates whether the match was successful or not.
      */
     private boolean tryMatch(TokenSet types) {
-        boolean match = types.contains(b.getTokenType());
+        boolean match = types.contains(tokenType());
         if (match) {
             advanceLexer();
         }
         return match;
     }
 
-    private void advanceLexer() {
-        b.advanceLexer();
-        if (b.getTokenType() == PREPROCESSOR_BEGIN) {
-            parsePreprocessor();
-        }
-    }
+    //Parsing code
 
+    /**
+     * Parses preprocessor, assuming that the tokenType() is at PREPROCESSOR_BEGIN.
+     * Called automatically on advanceLexer(), which means that elements may contain
+     * some tokens, that are part of preprocessor, not that element.
+     * This may cause trouble during working with the PSI tree, so be careful.
+     */
     private void parsePreprocessor() {
         // We can't use tryMatch etc. in here because we'll end up
         // potentially parsing a preprocessor directive inside this one.
-        PsiBuilder.Marker preprocessor = b.mark();
-        while (!b.eof()) {
-            b.advanceLexer();
-            if (b.getTokenType() == PREPROCESSOR_END) {
-                b.advanceLexer();
+        PsiBuilder.Marker preprocessor = mark();
+        while (!isEof()) {
+            //TODO If the directive is DEFINE or UNDEF, follow it
+            psiBuilder.advanceLexer();
+            if (tokenType() == PREPROCESSOR_END) {
+                psiBuilder.advanceLexer();
                 break;
             }
         }
         preprocessor.done(PREPROCESSOR_DIRECTIVE);
 
-        if (b.getTokenType() == PREPROCESSOR_BEGIN) {
+        if (tokenType() == PREPROCESSOR_BEGIN) {
             parsePreprocessor();
         }
     }
@@ -148,21 +243,21 @@ public final class GLSLParsing {
     public void parseTranslationUnit() {
         // translation_unit: external_declaration+
 
-        PsiBuilder.Marker unit = b.mark();
+        PsiBuilder.Marker unit = mark();
 
         // We normally parse preprocessor directives whenever we advance the lexer - which means that if the first
         // token is a preprocessor directive we won't catch it, so we just parse them all at the beginning here.
-        while (b.getTokenType() == PREPROCESSOR_BEGIN) {
+        while (tokenType() == PREPROCESSOR_BEGIN) {
             parsePreprocessor();
         }
 
         do {
             if (!parseExternalDeclaration()) {
                 advanceLexer();
-                b.error("Unable to parse external declaration.");
+                error("Unable to parse external declaration.");
             }
         }
-        while (!b.eof());
+        while (!isEof());
         unit.done(TRANSLATION_UNIT);
     }
 
@@ -181,25 +276,25 @@ public final class GLSLParsing {
         // Note: after type-specifier, we only need to look up IDENTIfIER '(' to determine
         //       whether or not it is a prototype or a declarator-list.
 
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         // This bunch of conditionals are responsible to handle really invalid input.
         // Specifically, when b.getTokenType() is not in the first set of external-declaration
         // Please add more if found lacking.
         // TODO: Add something similar to parseStatement
-        if (b.getTokenType() == LEFT_PAREN ||
-                CONSTANT_TOKENS.contains(b.getTokenType()) ||
-                UNARY_OPERATORS.contains(b.getTokenType())) {
+        if (tokenType() == LEFT_PAREN ||
+                CONSTANT_TOKENS.contains(tokenType()) ||
+                UNARY_OPERATORS.contains(tokenType())) {
             parseExpression();
             tryMatch(SEMICOLON);
             mark.error("Expression not allowed here.");
             return true;
         }
-        String text = b.getTokenText();
-        if (b.getTokenType() == IF_KEYWORD ||
-                b.getTokenType() == FOR_KEYWORD ||
-                b.getTokenType() == WHILE_KEYWORD ||
-                b.getTokenType() == DO_KEYWORD) {
+        String text = getTokenText();
+        if (tokenType() == IF_KEYWORD ||
+                tokenType() == FOR_KEYWORD ||
+                tokenType() == WHILE_KEYWORD ||
+                tokenType() == DO_KEYWORD) {
             parseSimpleStatement();
             mark.error("'" + text + "' statement not allowed here.");
             return true;
@@ -210,7 +305,7 @@ public final class GLSLParsing {
         }
         while (tryMatch(OPERATORS)) {
             mark.error("Unexpected token '" + text + "'.");
-            mark = b.mark();
+            mark = mark();
         }
 
         if(parsePrecisionStatement()) {
@@ -220,17 +315,17 @@ public final class GLSLParsing {
 
         parseQualifierList(true);
 
-        if (b.getTokenType() == IDENTIFIER && b.lookAhead(1) == LEFT_BRACE) { // interface block
+        if (tokenType() == IDENTIFIER && lookAhead(1) == LEFT_BRACE) { // interface block
             //TODO Make sure that this is preceded by storage_qualifier
             parseIdentifier();
             match(LEFT_BRACE, "Expected '{'");
 
-            if (b.getTokenType() == RIGHT_BRACE) {
-                b.error("Empty interface block is not allowed.");
+            if (tokenType() == RIGHT_BRACE) {
+                error("Empty interface block is not allowed.");
             }
             
             while (!tryMatch(RIGHT_BRACE) && !eof()) {
-                final PsiBuilder.Marker member = b.mark();
+                final PsiBuilder.Marker member = mark();
                 parseQualifierList(true);
                 if (!parseTypeSpecifierNoArray()) advanceLexer();
                 parseDeclaratorList();
@@ -238,9 +333,9 @@ public final class GLSLParsing {
                 member.done(STRUCT_DECLARATION);//TODO Should we call interface block members struct members?
             }
 
-            if (b.getTokenType() == IDENTIFIER) {
+            if (tokenType() == IDENTIFIER) {
                 parseIdentifier();
-                if (b.getTokenType() == LEFT_BRACKET) {
+                if (tokenType() == LEFT_BRACKET) {
                     parseArrayDeclarator();
                 }
             }
@@ -250,9 +345,9 @@ public final class GLSLParsing {
         }
 
         parseTypeSpecifier();
-        PsiBuilder.Marker postType = b.mark();
+        PsiBuilder.Marker postType = mark();
 
-        if (b.getTokenType() == SEMICOLON) {
+        if (tokenType() == SEMICOLON) {
             // Declaration with no declarators.
             // (struct definitions will look like this)
             postType.drop();
@@ -261,14 +356,14 @@ public final class GLSLParsing {
             mark.done(VARIABLE_DECLARATION);
             return true;
 
-        } else if (b.getTokenType() == IDENTIFIER || b.getTokenType() == LEFT_PAREN) {
+        } else if (tokenType() == IDENTIFIER || tokenType() == LEFT_PAREN) {
             // Identifier means either declarators, or function declaration/definition
             match(IDENTIFIER, "Missing function name");
 
-            if (b.getTokenType() == SEMICOLON ||
-                    b.getTokenType() == COMMA ||
-                    b.getTokenType() == LEFT_BRACKET ||
-                    b.getTokenType() == EQUAL) {
+            if (tokenType() == SEMICOLON ||
+                    tokenType() == COMMA ||
+                    tokenType() == LEFT_BRACKET ||
+                    tokenType() == EQUAL) {
                 // These are valid operatorTokens after an identifier in a declarator.
                 // ... try to parse declarator-list!
                 postType.rollbackTo();
@@ -282,7 +377,7 @@ public final class GLSLParsing {
                 // This must be a function declaration or definition, parse the prototype first!
                 postType.rollbackTo();
 
-                PsiBuilder.Marker declarator = b.mark();
+                PsiBuilder.Marker declarator = mark();
                 parseIdentifier();
                 declarator.done(DECLARATOR);
 
@@ -294,16 +389,16 @@ public final class GLSLParsing {
 
                 if (tryMatch(SEMICOLON)) {
                     mark.done(FUNCTION_DECLARATION);
-                } else if (b.getTokenType() == LEFT_BRACE) {
+                } else if (tokenType() == LEFT_BRACE) {
                     parseCompoundStatement();
                     mark.done(FUNCTION_DEFINITION);
                 } else {
                     // Neither ';' nor '{' found, mark as a prototype with missing ';'
                     mark.done(FUNCTION_DECLARATION);
-                    b.error("Missing ';' after function declaration.");
+                    error("Missing ';' after function declaration.");
                 }
                 return true;
-            } else if (TYPE_SPECIFIER_NONARRAY_TOKENS.contains(b.getTokenType())) {
+            } else if (TYPE_SPECIFIER_NONARRAY_TOKENS.contains(tokenType())) {
                 // simulate declarators, and return success to make parsing continue.
                 postType.done(IDENTIFIER);
                 postType = postType.precede();
@@ -311,16 +406,16 @@ public final class GLSLParsing {
                 postType = postType.precede();
                 postType.done(DECLARATOR_LIST);
                 mark.done(VARIABLE_DECLARATION);
-                b.error("Missing ';' after declaration.");
+                error("Missing ';' after declaration.");
                 return true;
             }
-        } else if (GLSLTokenTypes.OPERATORS.contains(b.getTokenType()) ||
-                b.getTokenType() == DOT ||
-                b.getTokenType() == LEFT_BRACKET) {
+        } else if (GLSLTokenTypes.OPERATORS.contains(tokenType()) ||
+                tokenType() == DOT ||
+                tokenType() == LEFT_BRACKET) {
             // this will handle most expressions
             postType.drop();
             mark.rollbackTo();
-            mark = b.mark();
+            mark = mark();
             if (!parseExpression()) {
                 //There is no expression! Consume what triggered me. (Would lead to infinite loop otherwise)
                 advanceLexer();
@@ -328,18 +423,18 @@ public final class GLSLParsing {
             tryMatch(SEMICOLON);
             mark.error("Expression not allowed here.");
             return true;
-        } else if (GLSLTokenTypes.FLOW_KEYWORDS.contains(b.getTokenType()) ||
-                GLSLTokenTypes.CONSTANT_TOKENS.contains(b.getTokenType())) {
+        } else if (GLSLTokenTypes.FLOW_KEYWORDS.contains(tokenType()) ||
+                GLSLTokenTypes.CONSTANT_TOKENS.contains(tokenType())) {
             postType.drop();
-            text = b.getTokenText();
+            text = getTokenText();
             advanceLexer();
             mark.error("Unexpected '" + text + "'");
             return true;
-        } else if (TYPE_SPECIFIER_NONARRAY_TOKENS.contains(b.getTokenType())) {
+        } else if (TYPE_SPECIFIER_NONARRAY_TOKENS.contains(tokenType())) {
             // simulate declarators, and return success to make parsing continue.
             postType.done(DECLARATOR_LIST);
             mark.done(VARIABLE_DECLARATION);
-            b.error("Missing ';' after declaration.");
+            error("Missing ';' after declaration.");
             return true;
         }
 
@@ -349,12 +444,12 @@ public final class GLSLParsing {
 
     private boolean parsePrecisionStatement(){
         // precision_statement: PRECISION precision_qualifier type_specifier_no_precision ;
-        if(b.getTokenType() == PRECISION_KEYWORD){
-            final PsiBuilder.Marker mark = b.mark();
+        if(tokenType() == PRECISION_KEYWORD){
+            final PsiBuilder.Marker mark = mark();
             advanceLexer();
             match(PRECISION_QUALIFIER, "Expected precision qualifier.");
             if(!parseTypeSpecifier()){
-                b.error("Expected type specifier.");
+                error("Expected type specifier.");
             }
             match(SEMICOLON, "Expected ';'");
             mark.done(PRECISION_STATEMENT);
@@ -373,12 +468,12 @@ public final class GLSLParsing {
         // parameter_declaration_list: <nothing>
         //                           | VOID
         //                           | parameter_declaration (',' parameter_declaration)*
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
         //noinspection StatementWithEmptyBody
         if (tryMatch(VOID_TYPE)) {
             // Do nothing.
-        } else if (b.getTokenType() != RIGHT_PAREN) {
+        } else if (tokenType() != RIGHT_PAREN) {
             do {
                 parseParameterDeclaration();
             } while (tryMatch(COMMA));
@@ -388,15 +483,15 @@ public final class GLSLParsing {
 
     private void parseParameterDeclaration() {
         // parameter_declaration: [parameter_qualifier] [type_qualifier] IDENTIFIER [array_declarator]
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
         parseQualifiedTypeSpecifier();
 
-        if (b.getTokenType() == IDENTIFIER) {
+        if (tokenType() == IDENTIFIER) {
             parseStructOrParameterDeclarator(PARAMETER_DECLARATOR);
         } else {
             // Fake a declarator.
-            PsiBuilder.Marker mark2 = b.mark();
+            PsiBuilder.Marker mark2 = mark();
             mark2.done(PARAMETER_DECLARATOR);
         }
 
@@ -406,10 +501,10 @@ public final class GLSLParsing {
     private void parseCompoundStatement() {
         // compound_statement: '{' '}'
         //                   | '{' statement_list '}'
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         match(LEFT_BRACE, "'{' expected.");
         if (eof(mark)) return;
-        if (b.getTokenType() != RIGHT_BRACE) {
+        if (tokenType() != RIGHT_BRACE) {
             parseStatementList();
         }
         if (eof()) {
@@ -420,27 +515,12 @@ public final class GLSLParsing {
         }
     }
 
-    private boolean eof(PsiBuilder.Marker... marksToClose) {
-        if (b.eof()) {
-            if (marksToClose.length > 0) {
-                for (PsiBuilder.Marker mark : marksToClose) {
-                    mark.error("Premature end of file.");
-                }
-            } else {
-                b.error("Premature end of file.");
-            }
-            return true;
-        } else {
-            return false;
-        }
-    }
-
     private void parseStatementList() {
         // statement_list: statement*
         // NOTE: terminates with '}', but we check for FirstSet(statement)
         //       instead for increased robustness
 
-        while ((STATEMENT_FIRST_SET.contains(b.getTokenType()) || OPERATORS.contains(b.getTokenType()) || b.getTokenType() == PRECISION_KEYWORD) && !eof()) {
+        while ((STATEMENT_FIRST_SET.contains(tokenType()) || OPERATORS.contains(tokenType()) || tokenType() == PRECISION_KEYWORD) && !eof()) {
             if (!parseStatement()) {
                 return;
             }
@@ -450,32 +530,32 @@ public final class GLSLParsing {
     private boolean parseStatement() {
         // statement: simple_statement | compound_statement
 
-        if (b.getTokenType() == LEFT_BRACE) {
+        if (tokenType() == LEFT_BRACE) {
             parseCompoundStatement();
             return true;
         }
         if (parseSimpleStatement()) {
             return true;
         } else {
-            final PsiBuilder.Marker mark = b.mark();
+            final PsiBuilder.Marker mark = mark();
             if (parsePrecisionStatement()) {
                 mark.error("Precision statement can be only in the top level.");
                 return true;
             } else {
                 mark.drop();
-                b.error("Expected a statement.");
+                error("Expected a statement.");
                 return false;
             }
         }
     }
 
     private void eatInvalidOperators() {
-        PsiBuilder.Marker mark = b.mark();
-        while (OPERATORS.contains(b.getTokenType())) {
-            String operator = b.getTokenText();
+        PsiBuilder.Marker mark = mark();
+        while (OPERATORS.contains(tokenType())) {
+            String operator = getTokenText();
             advanceLexer();
             mark.error("Unexpected operator '" + operator + "'.");
-            mark = b.mark();
+            mark = mark();
         }
         mark.drop();
     }
@@ -488,7 +568,7 @@ public final class GLSLParsing {
         //                 | jump_statement
         eatInvalidOperators();
 
-        final IElementType type = b.getTokenType();
+        final IElementType type = tokenType();
         boolean result;
 
         if (EXPRESSION_FIRST_SET.contains(type) || QUALIFIER_TOKENS.contains(type)) {
@@ -522,9 +602,9 @@ public final class GLSLParsing {
 
     private boolean parseReturnStatement() {
         // return_statement: 'return' [expression] ';'
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         match(RETURN_JUMP_STATEMENT, "Missing 'return'.");
-        if (b.getTokenType() != SEMICOLON) {
+        if (tokenType() != SEMICOLON) {
             parseExpression();
             match(SEMICOLON, "Missing ';' after expression.");
         } else {
@@ -536,7 +616,7 @@ public final class GLSLParsing {
 
     private boolean parseContinueStatement() {
         // discard_statement: 'continue' ';'
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         match(CONTINUE_JUMP_STATEMENT, "Missing 'continue'.");
         match(SEMICOLON, "Missing ';' after 'continue'.");
         mark.done(CONTINUE_STATEMENT);
@@ -545,7 +625,7 @@ public final class GLSLParsing {
 
     private boolean parseDiscardStatement() {
         // discard_statement: 'discard' ';'
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         match(DISCARD_JUMP_STATEMENT, "Missing 'discard'.");
         match(SEMICOLON, "Missing ';' after 'discard'.");
         mark.done(DISCARD_STATEMENT);
@@ -554,7 +634,7 @@ public final class GLSLParsing {
 
     private boolean parseBreakStatement() {
         // break_statement: 'break' ';'
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         match(BREAK_JUMP_STATEMENT, "Missing 'break'.");
         match(SEMICOLON, "Missing ';' after 'break'.");
         mark.done(BREAK_STATEMENT);
@@ -565,7 +645,7 @@ public final class GLSLParsing {
         // for_iteration_statement: 'for' '(' for_init_statement for_rest_statement ')' statement_no_new_scope
         // NOTE: refactored to:
         // for_iteration_statement: 'for' '(' (expression|declaration) ';' expression
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         match(FOR_KEYWORD, "Missing 'for'.");
         match(LEFT_PAREN, "Missing '(' after 'for'.");
@@ -573,12 +653,12 @@ public final class GLSLParsing {
         parseForInitStatement();
         match(SEMICOLON, "Missing ';' in for statement.");
 
-        if (b.getTokenType() != SEMICOLON) {
+        if (tokenType() != SEMICOLON) {
             parseCondition();
         }
         match(SEMICOLON, "Missing ';' in for statement.");
 
-        if (b.getTokenType() != RIGHT_PAREN) {
+        if (tokenType() != RIGHT_PAREN) {
             // Only parse the expression if it is present.
             parseExpression();
         }
@@ -596,14 +676,14 @@ public final class GLSLParsing {
         // NOTE: The spec, allows the condition expression in 'for' and 'while' loops
         //       to declare a single variable.
 
-        PsiBuilder.Marker conditionMark = b.mark();
+        PsiBuilder.Marker conditionMark = mark();
         if (lookaheadDeclarationStatement()) {
-            PsiBuilder.Marker mark = b.mark();
+            PsiBuilder.Marker mark = mark();
 
             parseQualifiedTypeSpecifier();
 
-            PsiBuilder.Marker list = b.mark();
-            PsiBuilder.Marker declarator = b.mark();
+            PsiBuilder.Marker list = mark();
+            PsiBuilder.Marker declarator = mark();
 
             parseIdentifier();
             match(EQUAL, "Missing '=' in condition initializer.");
@@ -623,35 +703,35 @@ public final class GLSLParsing {
     private void parseForInitStatement() {
         // for_init_statement: expression_statement | declaration_statement
 
-        if (b.getTokenType() == IDENTIFIER) {
+        if (tokenType() == IDENTIFIER) {
             // needs lookahead
-            PsiBuilder.Marker rollback = b.mark();
+            PsiBuilder.Marker rollback = mark();
             advanceLexer();
-            if (b.getTokenType() == IDENTIFIER) {
+            if (tokenType() == IDENTIFIER) {
                 // IDENTIFIER IDENTIFIER means declaration statement
                 // where the first is the type specifier
                 rollback.rollbackTo();
                 parseDeclaration();
-            } else if (OPERATORS.contains(b.getTokenType()) ||
-                    b.getTokenType() == DOT ||
-                    b.getTokenType() == LEFT_BRACKET ||
-                    b.getTokenType() == QUESTION ||
-                    b.getTokenType() == LEFT_PAREN) {
+            } else if (OPERATORS.contains(tokenType()) ||
+                    tokenType() == DOT ||
+                    tokenType() == LEFT_BRACKET ||
+                    tokenType() == QUESTION ||
+                    tokenType() == LEFT_PAREN) {
                 // This should be the complete follow set of IDENTIFIER in the
                 // context limited to expressions
                 rollback.rollbackTo();
                 parseExpression();
             }
 
-        } else if (TYPE_SPECIFIER_NONARRAY_TOKENS.contains(b.getTokenType()) ||
-                QUALIFIER_TOKENS.contains(b.getTokenType())) {
+        } else if (TYPE_SPECIFIER_NONARRAY_TOKENS.contains(tokenType()) ||
+                QUALIFIER_TOKENS.contains(tokenType())) {
             parseDeclaration();
-        } else if (UNARY_OPERATORS.contains(b.getTokenType()) ||
-                FUNCTION_IDENTIFIER_TOKENS.contains(b.getTokenType()) ||
-                b.getTokenType() == LEFT_PAREN) {
+        } else if (UNARY_OPERATORS.contains(tokenType()) ||
+                FUNCTION_IDENTIFIER_TOKENS.contains(tokenType()) ||
+                tokenType() == LEFT_PAREN) {
             parseExpression();
         } else //noinspection StatementWithEmptyBody
-            if (b.getTokenType() == SEMICOLON) {
+            if (tokenType() == SEMICOLON) {
             // Do nothing here
         } else {
             // Token not in first set, how did we end up here?
@@ -661,7 +741,7 @@ public final class GLSLParsing {
 
     private boolean parseDoIterationStatement() {
         // do_iteration_statement: 'do' statement 'while' '(' expression ')' ';'
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         match(DO_KEYWORD, "Missing 'do'.");
         parseStatement();
@@ -677,7 +757,7 @@ public final class GLSLParsing {
 
     private boolean parseWhileIterationStatement() {
         // while_iteration_statement: 'while' '(' expression ')' statement
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         match(WHILE_KEYWORD, "Missing 'while'.");
         match(LEFT_PAREN, "Missing '(' after 'while'.");
@@ -691,7 +771,7 @@ public final class GLSLParsing {
 
     private boolean parseSelectionStatement() {
         // selection_statement: 'if' '(' expression ')' statement [ 'else' statement ]
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         match(IF_KEYWORD, "Missing 'if'.");
         match(LEFT_PAREN, "Missing '(' after 'if'.");
@@ -713,7 +793,7 @@ public final class GLSLParsing {
 
     private boolean parseExpressionStatement() {
         // expression_statement: [expression] ';'
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         //noinspection StatementWithEmptyBody
         if (tryMatch(SEMICOLON)) {
@@ -731,7 +811,7 @@ public final class GLSLParsing {
 
     private boolean parseDeclarationStatement() {
         // declaration_statement: declaration
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         if (!parseDeclaration()) {
             mark.error("Expected declaration.");
@@ -751,7 +831,7 @@ public final class GLSLParsing {
      */
     private boolean lookaheadDeclarationStatement() {
         // they share type_specifier. So if found; look for the following identifier.
-        PsiBuilder.Marker rollback = b.mark();
+        PsiBuilder.Marker rollback = mark();
         try{
             if (tryMatch(QUALIFIER_TOKENS)) {
                 return true;
@@ -774,7 +854,7 @@ public final class GLSLParsing {
         // declaration: function_prototype SEMICOLON
         //            | init_declarator_list SEMICOLON
 
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         if(parseQualifiedTypeSpecifier()){
             parseDeclaratorList();
@@ -789,8 +869,8 @@ public final class GLSLParsing {
     private void parseDeclaratorList() {
         // init_declarator_list: fully_specified_type
         //                     | fully_specified_type declarator ( ',' declarator )*
-        PsiBuilder.Marker mark = b.mark();
-        if (b.getTokenType() == IDENTIFIER) {
+        PsiBuilder.Marker mark = mark();
+        if (tokenType() == IDENTIFIER) {
             do {
                 parseDeclarator();
             } while (tryMatch(COMMA));
@@ -800,13 +880,13 @@ public final class GLSLParsing {
 
     private void parseDeclarator() {
         // declarator: IDENTIFIER [ '[' [ constant_expression ] ']' ] [ '=' initializer ]
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
         parseIdentifier();
-        if (b.getTokenType() == LEFT_BRACKET) {
+        if (tokenType() == LEFT_BRACKET) {
             parseArrayDeclarator();
         }
         if (tryMatch(EQUAL)) {
-            final PsiBuilder.Marker mark2 = b.mark();
+            final PsiBuilder.Marker mark2 = mark();
 
             parseInitializer();
 
@@ -816,18 +896,18 @@ public final class GLSLParsing {
     }
 
     private void parseArrayDeclarator() {//TODO Support multi-dimensional arrays (since 4.3)
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
         match(LEFT_BRACKET, "Expected '['.");
-        if (b.getTokenType() != RIGHT_BRACKET) {
+        if (tokenType() != RIGHT_BRACKET) {
             parseConstantExpression();
         }
         match(RIGHT_BRACKET, "Missing closing ']' after array declarator.");
 
         mark.done(ARRAY_DECLARATOR);
 
-        if (b.getTokenType() == LEFT_BRACKET) {
-            PsiBuilder.Marker err = b.mark();
+        if (tokenType() == LEFT_BRACKET) {
+            PsiBuilder.Marker err = mark();
             while (tryMatch(LEFT_BRACKET)) {
                 parseConstantExpression();
                 match(RIGHT_BRACKET, "Missing closing ']' after array declarator.");
@@ -847,7 +927,7 @@ public final class GLSLParsing {
         // NOTE: both conditional_expression and assignment_expression starts with unary_expression
         // CHANGED TO: (to reduce the need for lookahead. use the annotation passs to verify l-values)
         // assignment_expression: conditional_expression (assignment_operator conditional_expression)*
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         if (!parseConditionalExpression()) {
             mark.drop();
@@ -867,7 +947,7 @@ public final class GLSLParsing {
     private boolean parseConditionalExpression() {
         // conditional_expression: logical_or_expression
         //                       | logical_or_expression QUESTION expression COLON assignment_expression
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         if (!parseOperatorExpression()) {
             mark.drop();
             return false;
@@ -890,7 +970,7 @@ public final class GLSLParsing {
         // transformed to:
         // expression: assignment_expression (',' assignment_expression)*
 
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         if (!parseAssignmentExpression()) {
             mark.error("Expected an expression.");
@@ -914,7 +994,7 @@ public final class GLSLParsing {
     }
 
     private boolean parseOperatorExpression(int level) {
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         if (!parseOperatorExpressionLevel(level + 1)) {
             mark.drop();
             return false;
@@ -926,7 +1006,7 @@ public final class GLSLParsing {
                 mark.done(operatorLevel.getElementType());
                 mark = mark.precede();
             } else {
-                PsiBuilder.Marker operatorMark = b.mark();
+                PsiBuilder.Marker operatorMark = mark();
                 if (tryMatch(OPERATORS)) {
                     do {
                         operatorMark.error("Operator out of place.");
@@ -935,7 +1015,7 @@ public final class GLSLParsing {
                             mark = mark.precede();
                             break;
                         } else {
-                            operatorMark = b.mark();
+                            operatorMark = mark();
                         }
                     } while (tryMatch(OPERATORS));
                 } else {
@@ -961,7 +1041,7 @@ public final class GLSLParsing {
         // unary_expression: postfix_expression
         //                 | unary_operator unary_expression
         // note: moved INC_OP and DEC_OP to unary_operator
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         if (tryMatch(UNARY_OPERATORS)) {
             parseUnaryExpression();
@@ -985,7 +1065,7 @@ public final class GLSLParsing {
         //                   | postfix_expression DEC_OP
         // (moved from function_or_method_call:)
         //                   | postfix_expression '.' function_call
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         boolean result;
         if (lookupFunctionCall()) {
             result = parseFunctionCall();
@@ -1028,7 +1108,7 @@ public final class GLSLParsing {
      * @return true if the sequence contains a method call, false otherwise.
      */
     private boolean lookaheadMethodCall() {
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
         boolean result = false;
 
         if (tryMatch(TYPE_SPECIFIER_NONARRAY_TOKENS)) {
@@ -1054,7 +1134,7 @@ public final class GLSLParsing {
         // They should probably be reserved, but they're included since
         // they're in the spec.
         // It turns out that arrays support the length() method.
-        PsiBuilder.Marker rollback = b.mark();
+        PsiBuilder.Marker rollback = mark();
         boolean result = false;
 
         if (tryMatch(TYPE_SPECIFIER_NONARRAY_TOKENS)) {
@@ -1069,7 +1149,7 @@ public final class GLSLParsing {
     }
 
     private boolean parseFunctionCall() {
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
         parseFunctionCallImpl(false);
 
@@ -1093,10 +1173,10 @@ public final class GLSLParsing {
     private String parseFunctionIdentifier(boolean markAsMethodIdentifier) {
         // function_identifier: IDENTIFIER
         //                    | type_name [ array_declarator ] 
-        PsiBuilder.Marker mark = b.mark();
-        String name = b.getTokenText();
+        PsiBuilder.Marker mark = mark();
+        String name = getTokenText();
         if (tryMatch(FUNCTION_IDENTIFIER_TOKENS)) {
-            if (b.getTokenType() == LEFT_BRACKET) {
+            if (tokenType() == LEFT_BRACKET) {
                 parseArrayDeclarator();
             }
             mark.done(markAsMethodIdentifier ? METHOD_NAME : FUNCTION_NAME);
@@ -1110,17 +1190,17 @@ public final class GLSLParsing {
     private void parseParameterList() {
         // parameter_list: VOID | (nothing)
         //               | assignment_expression (',' assignment_expression)
-        PsiBuilder.Marker mark = b.mark();
+        PsiBuilder.Marker mark = mark();
 
-        if (b.getTokenType() == VOID_TYPE) {
+        if (tokenType() == VOID_TYPE) {
             advanceLexer();
         } else //noinspection StatementWithEmptyBody
-            if (b.getTokenType() == RIGHT_PAREN) {
+            if (tokenType() == RIGHT_PAREN) {
             // do nothing
         } else if (parseAssignmentExpression()) {
             while (tryMatch(COMMA)) {
                 if (!parseAssignmentExpression()) {
-                    b.error("Assignment expression expected.");
+                    error("Assignment expression expected.");
                     break;
                 }
             }
@@ -1136,10 +1216,10 @@ public final class GLSLParsing {
         // primary_expression: variable_identifier
         //                   | CONSTANT
         //                   | '(' expression ')'
-        final PsiBuilder.Marker mark = b.mark();
-        final IElementType type = b.getTokenType();
+        final PsiBuilder.Marker mark = mark();
+        final IElementType type = tokenType();
         if (type == IDENTIFIER) {
-            final PsiBuilder.Marker mark2 = b.mark();
+            final PsiBuilder.Marker mark2 = mark();
             advanceLexer();
             mark2.done(VARIABLE_NAME);
             mark.done(VARIABLE_NAME_EXPRESSION);
@@ -1150,8 +1230,8 @@ public final class GLSLParsing {
         } else if (type == LEFT_PAREN) {
             advanceLexer();
             if (!parseExpression()) {
-                if (b.getTokenType() == RIGHT_PAREN) {
-                    b.error("Expected expression after '('");
+                if (tokenType() == RIGHT_PAREN) {
+                    error("Expected expression after '('");
                 } else {
                     mark.error("Expected expression after '('");
                     return false;
@@ -1167,10 +1247,10 @@ public final class GLSLParsing {
     }
 
     private String parseIdentifier() {
-        final PsiBuilder.Marker mark = b.mark();
-        boolean success = b.getTokenType() == IDENTIFIER;
+        final PsiBuilder.Marker mark = mark();
+        boolean success = tokenType() == IDENTIFIER;
         if (success) {
-            String name = b.getTokenText();
+            String name = getTokenText();
             advanceLexer();
             mark.done(VARIABLE_NAME);
             return name;
@@ -1181,10 +1261,10 @@ public final class GLSLParsing {
     }
 
     private String parseFieldIdentifier() {
-        final PsiBuilder.Marker mark = b.mark();
-        boolean success = b.getTokenType() == IDENTIFIER;
+        final PsiBuilder.Marker mark = mark();
+        boolean success = tokenType() == IDENTIFIER;
         if (success) {
-            String name = b.getTokenText();
+            String name = getTokenText();
             advanceLexer();
             mark.done(FIELD_NAME);
             return name;
@@ -1198,14 +1278,14 @@ public final class GLSLParsing {
         // type_specifier_noarray
         // type_specifier_noarray "[" const_expr "]"
 
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
         if (!parseTypeSpecifierNoArray()) {
             mark.drop();
             return false;
         }
 
-        if (b.getTokenType() == LEFT_BRACKET) {
+        if (tokenType() == LEFT_BRACKET) {
             parseArrayDeclarator();
         }
         mark.done(TYPE_SPECIFIER);
@@ -1224,15 +1304,15 @@ public final class GLSLParsing {
         // todo: implement       | INVARIANT IDENTIFIER  (vertex only)
         // note: This also accepts IDENTIFIERS
 
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
-        if (b.getTokenType() == STRUCT) {
+        if (tokenType() == STRUCT) {
             parseStructSpecifier();
             mark.done(TYPE_SPECIFIER_STRUCT);
-        } else if (TYPE_SPECIFIER_NONARRAY_TOKENS.contains(b.getTokenType())) {
+        } else if (TYPE_SPECIFIER_NONARRAY_TOKENS.contains(tokenType())) {
             advanceLexer();
             mark.done(TYPE_SPECIFIER_PRIMITIVE);
-        } else if (b.getTokenType() == IDENTIFIER) {
+        } else if (tokenType() == IDENTIFIER) {
             parseIdentifier();
             mark.done(TYPE_SPECIFIER_STRUCT_REFERENCE);
         } else {
@@ -1250,7 +1330,7 @@ public final class GLSLParsing {
 
         match(STRUCT, "Expected 'struct'.");
 
-        if (b.getTokenType() == IDENTIFIER) {
+        if (tokenType() == IDENTIFIER) {
             parseIdentifier();
         }
 
@@ -1265,14 +1345,14 @@ public final class GLSLParsing {
         // struct_declaration_list: struct_declaration (',' struct_declaration)*
         // note: we should initially find ',' for a new declarator or '}' at the end of the struct
 
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
-        if (b.getTokenType() == RIGHT_BRACE) {
-            b.error("Empty struct is not allowed.");
+        if (tokenType() == RIGHT_BRACE) {
+            error("Empty struct is not allowed.");
         }
 
-        while (GLSLTokenTypes.TYPE_SPECIFIER_NONARRAY_TOKENS.contains(b.getTokenType()) ||
-                b.getTokenType() == GLSLTokenTypes.IDENTIFIER) {
+        while (GLSLTokenTypes.TYPE_SPECIFIER_NONARRAY_TOKENS.contains(tokenType()) ||
+                tokenType() == GLSLTokenTypes.IDENTIFIER) {
             parseStructDeclaration();
         }
 
@@ -1282,7 +1362,7 @@ public final class GLSLParsing {
     private void parseStructDeclaration() {
         // type_specifier struct_declarator_list ';'
 
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
         parseQualifiedTypeSpecifier();
         parseStructDeclaratorList();
@@ -1294,7 +1374,7 @@ public final class GLSLParsing {
     private void parseStructDeclaratorList() {
         // struct_declarator_list: struct_declarator (',' struct_declarator)*
 
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
         do {
             if (eof(mark)) return;
             parseStructOrParameterDeclarator(STRUCT_DECLARATOR);
@@ -1315,17 +1395,17 @@ public final class GLSLParsing {
 
         assert type == STRUCT_DECLARATOR || type == PARAMETER_DECLARATOR;
 
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
         parseIdentifier();
 
-        if (b.getTokenType() == LEFT_BRACKET) {
+        if (tokenType() == LEFT_BRACKET) {
             advanceLexer();
             parseConstantExpression();
             match(RIGHT_BRACKET, "Expected ']' after constant expression.");
         }
 
-        PsiBuilder.Marker declaratorEnd = b.mark();
+        PsiBuilder.Marker declaratorEnd = mark();
         if (tryMatch(EQUAL)) {
             parseInitializer();
             declaratorEnd.error("Initializer not allowed here.");
@@ -1337,7 +1417,7 @@ public final class GLSLParsing {
 
     private void parseQualifierList(boolean validPlacement) {
 
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
         if (!validPlacement && !parseQualifier()) {
             mark.drop();
@@ -1358,8 +1438,8 @@ public final class GLSLParsing {
     private boolean parseQualifier() {
         // qualifier: LAYOUT '(' layout_qualifier_id_list ')'
         //          | qualifier_token
-        if (QUALIFIER_TOKENS.contains(b.getTokenType())) {
-            final PsiBuilder.Marker mark = b.mark();
+        if (QUALIFIER_TOKENS.contains(tokenType())) {
+            final PsiBuilder.Marker mark = mark();
 
             if (tryMatch(LAYOUT_KEYWORD)) {
                 match(LEFT_PAREN, "Expected '('");
@@ -1386,11 +1466,11 @@ public final class GLSLParsing {
     private void parseLayoutQualifierElement() {
         // layout_qualifier_id: IDENTIFIER [ EQUAL constant_expression ]
         //                    | SHARED
-        final PsiBuilder.Marker mark = b.mark();
+        final PsiBuilder.Marker mark = mark();
 
         if (tryMatch(IDENTIFIER)) {
             if (tryMatch(EQUAL)) {
-                if (!parseConstantExpression()) b.error("Expected constant expression");
+                if (!parseConstantExpression()) error("Expected constant expression");
             }
         } else if (!tryMatch(SHARED_KEYWORD)) {
             mark.error("Expected 'shared' or an identifier");

--- a/src/glslplugin/lang/parser/GLSLParsing.java
+++ b/src/glslplugin/lang/parser/GLSLParsing.java
@@ -58,10 +58,11 @@ public final class GLSLParsing {
     };
 
 
-    /** The source of operatorTokens and the target for the AST nodes.
+    /**
+     * The source of operatorTokens and the target for the AST nodes.
      * Do not use directly, use specialized proxy functions below, which can handle preprocessor
      * directives and macro replacements.
-     * */
+     */
     private final PsiBuilder psiBuilder;
 
     GLSLParsing(PsiBuilder builder) {
@@ -94,6 +95,7 @@ public final class GLSLParsing {
      * for example done() to complete the element,
      * error() to mark element as invalid (error on the mark, not {@link GLSLParsing#error(String)}!)
      * or drop() to cancel the mark altogether.
+     *
      * @return placed mark
      */
     @NotNull
@@ -103,6 +105,7 @@ public final class GLSLParsing {
 
     /**
      * Places an error at current lexer position.
+     *
      * @param error message to be shown
      */
     private void error(String error) {
@@ -112,6 +115,7 @@ public final class GLSLParsing {
     /**
      * Returns same as eof(), but does not complain about anything
      * and doesn't close anything.
+     *
      * @return whether or not is the lexer at the end of the file
      */
     private boolean isEof() {
@@ -139,6 +143,7 @@ public final class GLSLParsing {
      * Checks whether lexer is at the end of the file,
      * complains about it if it is
      * and closes all marks supplied (if eof).
+     *
      * @return psiBuilder.eof()
      */
     private boolean eof(PsiBuilder.Marker... marksToClose) {
@@ -308,7 +313,7 @@ public final class GLSLParsing {
             mark = mark();
         }
 
-        if(parsePrecisionStatement()) {
+        if (parsePrecisionStatement()) {
             mark.drop();
             return true;
         }
@@ -323,7 +328,7 @@ public final class GLSLParsing {
             if (tokenType() == RIGHT_BRACE) {
                 error("Empty interface block is not allowed.");
             }
-            
+
             while (!tryMatch(RIGHT_BRACE) && !eof()) {
                 final PsiBuilder.Marker member = mark();
                 parseQualifierList(true);
@@ -442,19 +447,19 @@ public final class GLSLParsing {
         return false;
     }
 
-    private boolean parsePrecisionStatement(){
+    private boolean parsePrecisionStatement() {
         // precision_statement: PRECISION precision_qualifier type_specifier_no_precision ;
-        if(tokenType() == PRECISION_KEYWORD){
+        if (tokenType() == PRECISION_KEYWORD) {
             final PsiBuilder.Marker mark = mark();
             advanceLexer();
             match(PRECISION_QUALIFIER, "Expected precision qualifier.");
-            if(!parseTypeSpecifier()){
+            if (!parseTypeSpecifier()) {
                 error("Expected type specifier.");
             }
             match(SEMICOLON, "Expected ';'");
             mark.done(PRECISION_STATEMENT);
             return true;
-        }else return false;
+        } else return false;
     }
 
     private boolean parseQualifiedTypeSpecifier() {
@@ -732,11 +737,11 @@ public final class GLSLParsing {
             parseExpression();
         } else //noinspection StatementWithEmptyBody
             if (tokenType() == SEMICOLON) {
-            // Do nothing here
-        } else {
-            // Token not in first set, how did we end up here?
-            // TODO: Add error handling!
-        }
+                // Do nothing here
+            } else {
+                // Token not in first set, how did we end up here?
+                // TODO: Add error handling!
+            }
     }
 
     private boolean parseDoIterationStatement() {
@@ -832,7 +837,7 @@ public final class GLSLParsing {
     private boolean lookaheadDeclarationStatement() {
         // they share type_specifier. So if found; look for the following identifier.
         PsiBuilder.Marker rollback = mark();
-        try{
+        try {
             if (tryMatch(QUALIFIER_TOKENS)) {
                 return true;
             }
@@ -856,11 +861,11 @@ public final class GLSLParsing {
 
         PsiBuilder.Marker mark = mark();
 
-        if(parseQualifiedTypeSpecifier()){
+        if (parseQualifiedTypeSpecifier()) {
             parseDeclaratorList();
             mark.done(VARIABLE_DECLARATION);
             return true;
-        }else{
+        } else {
             mark.error("Qualified type specifier expected.");
             return false;
         }
@@ -1020,7 +1025,7 @@ public final class GLSLParsing {
                     } while (tryMatch(OPERATORS));
                 } else {
                     operatorMark.drop();
-                    mark.error("Expected a(n) "+operatorLevel.getPartName()+".");
+                    mark.error("Expected a(n) " + operatorLevel.getPartName() + ".");
                     return false;
                 }
             }
@@ -1196,18 +1201,18 @@ public final class GLSLParsing {
             advanceLexer();
         } else //noinspection StatementWithEmptyBody
             if (tokenType() == RIGHT_PAREN) {
-            // do nothing
-        } else if (parseAssignmentExpression()) {
-            while (tryMatch(COMMA)) {
-                if (!parseAssignmentExpression()) {
-                    error("Assignment expression expected.");
-                    break;
+                // do nothing
+            } else if (parseAssignmentExpression()) {
+                while (tryMatch(COMMA)) {
+                    if (!parseAssignmentExpression()) {
+                        error("Assignment expression expected.");
+                        break;
+                    }
                 }
+            } else {
+                mark.error("Expression expected after '('.");
+                return;
             }
-        } else {
-            mark.error("Expression expected after '('.");
-            return;
-        }
 
         mark.done(PARAMETER_LIST);
     }

--- a/src/glslplugin/lang/parser/GLSLParsingBase.java
+++ b/src/glslplugin/lang/parser/GLSLParsingBase.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2010 Jean-Paul Balabanian and Yngve Devik Hammersland
+ *
+ *     This file is part of glsl4idea.
+ *
+ *     Glsl4idea is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as
+ *     published by the Free Software Foundation, either version 3 of
+ *     the License, or (at your option) any later version.
+ *
+ *     Glsl4idea is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package glslplugin.lang.parser;
+
+import com.intellij.lang.PsiBuilder;
+import com.intellij.lang.impl.DelegateMarker;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static glslplugin.lang.elements.GLSLElementTypes.PREPROCESSED_EMPTY;
+import static glslplugin.lang.elements.GLSLTokenTypes.IDENTIFIER;
+import static glslplugin.lang.elements.GLSLTokenTypes.PREPROCESSOR_BEGIN;
+
+/**
+ * Base of GLSLParsing to clearly divide helper and parsing methods.
+ * This class contains the helper methods.
+ *
+ * @author Darkyen
+ */
+abstract class GLSLParsingBase {
+
+    /**
+     * The source of operatorTokens and the target for the AST nodes.
+     * Do not use directly, use specialized proxy functions below, which can handle preprocessor
+     * directives and macro replacements.
+     */
+    protected final PsiBuilder psiBuilder;
+
+    GLSLParsingBase(PsiBuilder builder) {
+        psiBuilder = builder;
+    }
+
+    //Code that deals with preprocessor, b.call replacements
+
+    protected final HashMap<String, PreprocessorDropIn> defines = new HashMap<String, PreprocessorDropIn>();
+
+    /** List of tokens to serve, because the real psiBuilder is currently on #define-d IDENTIFIER.
+     * If null, psiBuilder is not there and everything is normal. */
+    protected List<PreprocessorToken> preprocessorTokens = null;
+    /** How far in preprocessorTokens is parser advanced. */
+    protected int preprocessorTokensIndex = -1;
+    /** Original text of `preprocessorTokens`. Used for UI and debug. */
+    private String preprocessorTokensText = null;
+    /** Value of preprocessorTokensText before calling consumePreprocessorTokens(). (For convenience) */
+    protected String preprocessorTextOfConsumedTokens = null;
+
+    private PreprocessorDropInType preprocessorTokensReplacementType = PreprocessorDropInType.UNKNOWN;
+
+    /**
+     * @return type of token lexer is at or null if eof
+     */
+    @Nullable
+    protected final IElementType tokenType() {
+        if(preprocessorTokens != null){
+            return preprocessorTokens.get(preprocessorTokensIndex).type;
+        } else {
+            return psiBuilder.getTokenType();
+        }
+    }
+
+    /**
+     * @return type of token after [amount] times calling advanceLexer()
+     */
+    @Nullable
+    protected final IElementType lookAhead(int amount) {
+        return psiBuilder.lookAhead(amount); //TODO Implement for preprocessor
+    }
+
+    /**
+     * Places a mark at token.
+     * This mark MUST be closed by calling functions on it,
+     * for example done() to complete the element,
+     * error() to mark element as invalid (error on the mark, not {@link GLSLParsing#error(String)}!)
+     * or drop() to cancel the mark altogether.
+     *
+     * @return placed mark
+     */
+    @NotNull
+    protected final PsiBuilder.Marker mark() {
+        //This will have to do.
+        //If token is expanded to more tokens, it will be hard to mark mid-token.
+        return new GLSLMarkerDelegate(psiBuilder.mark());
+    }
+
+    private final class GLSLMarkerDelegate extends DelegateMarker {
+
+        private final int markPreprocessorTokensIndex;
+
+        public GLSLMarkerDelegate(@NotNull PsiBuilder.Marker delegate) {
+            super(delegate);
+            markPreprocessorTokensIndex = preprocessorTokensIndex;
+        }
+
+        public GLSLMarkerDelegate(@NotNull PsiBuilder.Marker delegate, int markPreprocessorTokensIndex) {
+            super(delegate);
+            this.markPreprocessorTokensIndex = markPreprocessorTokensIndex;
+        }
+
+        @Override
+        public void rollbackTo() {
+            super.rollbackTo();
+            //Reinitialize replacement tokens
+            preprocessorTokens = null;
+            preprocessorTokensIndex = -1;
+            preprocessorTokensReplacementType = null;
+            advanceLexer_initializePreprocessorToken(psiBuilder.getTokenType());
+            preprocessorTokensIndex = markPreprocessorTokensIndex;
+        }
+
+        @Override
+        public PsiBuilder.Marker precede() {
+            return new GLSLMarkerDelegate(super.precede(), markPreprocessorTokensIndex);
+        }
+    }
+
+    /**
+     * Places an error at current lexer position.
+     *
+     * @param error message to be shown
+     */
+    protected final void error(String error) {
+        //This is probably fine preprocessor-define wise.
+        psiBuilder.error(error);
+    }
+
+    /**
+     * Returns same as eof(), but does not complain about anything
+     * and doesn't close anything.
+     *
+     * @return whether or not is the lexer at the end of the file
+     */
+    protected final boolean isEof() {
+        //noinspection SimplifiableIfStatement
+        if(preprocessorTokens != null && preprocessorTokensIndex < preprocessorTokens.size()){
+            return false;
+        }else return psiBuilder.eof();
+    }
+
+    /**
+     * @return the text of current token
+     */
+    @Nullable
+    protected final String getTokenText() {
+        if(preprocessorTokens != null){
+            return preprocessorTokens.get(preprocessorTokensIndex).text;
+        } else {
+            return psiBuilder.getTokenText();
+        }
+    }
+
+    /**
+     * Iff advanceLexer() just advanced into the preprocessor redefined tokens,
+     * this method will return what type of redefinition should happen here.
+     * If no type of replacement was recognized, type will be {@link PreprocessorDropInType#UNKNOWN}.
+     *
+     * Parsing methods can call this before doing their job, to find if it is already parsed.
+     * If it is, they should mark the spot for special drop in element, consumePreprocessorTokens() and return true.
+     * There is a shorthand to that, isTokenPreprocessorAlias(PreprocessorDropInType).
+     *
+     * @return Replacement type if just encountered the preprocessor-replaced block, null otherwise
+     */
+    @Nullable
+    protected final PreprocessorDropInType getTokenPreprocessorAlias(){
+        if(preprocessorTokens != null && preprocessorTokensIndex == 0){
+            return preprocessorTokensReplacementType;
+        }else{
+            return null;
+        }
+    }
+
+    /**
+     * Checks if next token is preprocessor alias for given type.
+     * If it is, consumes all injected tokens for that preprocessor token and return true.
+     * Otherwise false.
+     */
+    protected final boolean isTokenPreprocessorAlias(PreprocessorDropInType type){
+        if(getTokenPreprocessorAlias() == type){
+            consumePreprocessorTokens();
+            return true;
+        }else{
+            return false;
+        }
+    }
+
+    /**
+     * Advances lexer over all preprocessor-injected tokens.
+     * Does nothing if not in preprocessor-injected tokens.
+     */
+    protected final void consumePreprocessorTokens(){
+        if(preprocessorTokens != null){
+            preprocessorTextOfConsumedTokens = preprocessorTokensText;
+            preprocessorTokensIndex = preprocessorTokens.size();
+            advanceLexer();
+        }
+    }
+
+    private void advanceLexer_initializePreprocessorToken(final IElementType tokenType){
+        boolean rerolling = (tokenType instanceof GLSLRedefinedTokenType);
+        if (tokenType == IDENTIFIER || rerolling) {
+            //It may be preprocessor defined identifier
+            final String text = psiBuilder.getTokenText();
+            final PreprocessorDropIn dropIn = defines.get(text);
+
+            if (dropIn != null) {
+                preprocessorTokensReplacementType = dropIn.type;
+                final List<PreprocessorToken> tokens = dropIn.tokens;
+                preprocessorTokensText = dropIn.text;
+                //This IDENTIFIER has been #define-d to tokens
+                if(!rerolling)psiBuilder.remapCurrentToken(new GLSLRedefinedTokenType(tokens));
+
+                preprocessorTokens = tokens;
+                preprocessorTokensIndex = 0;
+            }// else There is nothing defined to this, continue normally
+        }
+    }
+
+    /**
+     * Advance lexer by one token.
+     *
+     * This goes through preprocessor-injected tokens,
+     * skips empty-injected tokens and parses more preprocessor directives.
+     */
+    protected final void advanceLexer(){
+        PsiBuilder.Marker emptyReplacementMarker = null;
+        int advances = 0;
+        do {
+            advances++;
+            if(advances == 2)emptyReplacementMarker = mark();
+            boolean advancedRealLexer = false;
+
+            if (preprocessorTokens != null) {
+                //In defined mode
+                //Go to next token
+                preprocessorTokensIndex++;
+                if (preprocessorTokensIndex >= preprocessorTokens.size()) {
+                    //At the end, jump out of preprocessor mode and advance real lexer instead
+                    preprocessorTokens = null;
+                    preprocessorTokensReplacementType = null;
+                    preprocessorTokensIndex = -1;
+                    psiBuilder.advanceLexer();
+                    advancedRealLexer = true;
+                }
+            } else {
+                //Not in defined mode
+                psiBuilder.advanceLexer();
+                advancedRealLexer = true;
+            }
+
+            if (advancedRealLexer) {
+                //Real lexer advanced, so check for directives and redefined tokens
+                IElementType tokenType = psiBuilder.getTokenType();
+                if (tokenType == PREPROCESSOR_BEGIN) {
+                    parsePreprocessor();
+                } else {
+                    advanceLexer_initializePreprocessorToken(tokenType);
+                }
+            }
+        } while (preprocessorTokensReplacementType == PreprocessorDropInType.EMPTY);
+        if(emptyReplacementMarker != null){
+            emptyReplacementMarker.done(PREPROCESSED_EMPTY);
+        }
+    }
+
+    //Utility code
+
+    /**
+     * Checks whether lexer is at the end of the file,
+     * complains about it if it is
+     * and closes all marks supplied (if eof).
+     *
+     * @return psiBuilder.eof()
+     */
+    protected final boolean eof(PsiBuilder.Marker... marksToClose) {
+        if (isEof()) {
+            if (marksToClose.length > 0) {
+                for (PsiBuilder.Marker mark : marksToClose) {
+                    mark.error("Premature end of file.");
+                }
+            } else {
+                error("Premature end of file.");
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Verifies that the current token is of the given type, if not it will flag an error.
+     *
+     * @param type  the expected token type.
+     * @param error an appropriate error message if any other token is found instead.
+     * @return indicates whether the match was successful or not.
+     */
+    protected final boolean match(IElementType type, String error) {
+        if (isEof()) {
+            return false;
+        }
+        boolean match = tokenType() == type;
+        if (match) {
+            advanceLexer();
+        } else {
+            error(error);
+        }
+        return match;
+    }
+
+    /**
+     * Consumes the next token if it is of the given types, otherwise it is ignored.
+     *
+     * @param types the expected token types.
+     * @return indicates whether the match was successful or not.
+     */
+    protected final boolean tryMatch(IElementType... types) {
+        if (isEof()) {
+            return false;
+        }
+        boolean match = false;
+        for (IElementType type : types) {
+            match |= tokenType() == type;
+        }
+        if (match) {
+            advanceLexer();
+        }
+        return match;
+    }
+
+    /**
+     * Consumes the next token if it is contained in the given token set, otherwise it is ignored.
+     *
+     * @param types a token set containing the expected token types.
+     * @return indicates whether the match was successful or not.
+     */
+    protected final boolean tryMatch(TokenSet types) {
+        boolean match = types.contains(tokenType());
+        if (match) {
+            advanceLexer();
+        }
+        return match;
+    }
+
+    // Interface to implementation
+
+    protected abstract void parsePreprocessor();
+}

--- a/src/glslplugin/lang/parser/GLSLParsingBase.java
+++ b/src/glslplugin/lang/parser/GLSLParsingBase.java
@@ -109,7 +109,7 @@ abstract class GLSLParsingBase {
             fallback.rollbackTo();
             return result;
         }else{
-            return IDENTIFIER;
+            return lookahead;
         }
     }
 

--- a/src/glslplugin/lang/parser/GLSLRedefinedTokenType.java
+++ b/src/glslplugin/lang/parser/GLSLRedefinedTokenType.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public final class GLSLRedefinedTokenType extends IElementType {
 
-    private final List<PreprocessorToken> redefinedTo;
+    public final List<PreprocessorToken> redefinedTo;
 
     protected GLSLRedefinedTokenType(List<PreprocessorToken> redefinedTo) {
         super("GLSLRedefinedToken", GLSLLanguage.GLSL_LANGUAGE, false);

--- a/src/glslplugin/lang/parser/GLSLRedefinedTokenType.java
+++ b/src/glslplugin/lang/parser/GLSLRedefinedTokenType.java
@@ -19,12 +19,8 @@
 
 package glslplugin.lang.parser;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.GLSLLanguage;
-import glslplugin.lang.elements.GLSLElement;
 
 import java.util.List;
 
@@ -40,38 +36,4 @@ public final class GLSLRedefinedTokenType extends IElementType {
         this.redefinedTo = redefinedTo;
     }
 
-    public static final class GLSLRedefinedPsiElement extends ASTWrapperPsiElement implements GLSLElement {
-
-        private final GLSLRedefinedTokenType type;
-
-        public GLSLRedefinedPsiElement(ASTNode node, GLSLRedefinedTokenType type) {
-            super(node);
-            this.type = type;
-        }
-
-        @Override
-        public <T extends GLSLElement> T findParentByClass(Class<T> clazz) {
-            return null;//TODO Impl
-        }
-
-        @Override
-        public GLSLElement findParentByClasses(Class<? extends GLSLElement>... clazzes) {
-            return null;//TODO Impl
-        }
-
-        @Override
-        public <T extends GLSLElement> T findPrevSiblingByClass(Class<T> clazz) {
-            return null;//TODO Impl
-        }
-
-        @Override
-        public GLSLElement findPrevSiblingByClasses(Class<? extends GLSLElement>... clazzes) {
-            return null;//TODO Impl
-        }
-
-        @Override
-        public boolean isDescendantOf(PsiElement ancestor) {
-            return false;//TODO Impl
-        }
-    }
 }

--- a/src/glslplugin/lang/parser/GLSLRedefinedTokenType.java
+++ b/src/glslplugin/lang/parser/GLSLRedefinedTokenType.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2010 Jean-Paul Balabanian and Yngve Devik Hammersland
+ *
+ *     This file is part of glsl4idea.
+ *
+ *     Glsl4idea is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as
+ *     published by the Free Software Foundation, either version 3 of
+ *     the License, or (at your option) any later version.
+ *
+ *     Glsl4idea is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package glslplugin.lang.parser;
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.tree.IElementType;
+import glslplugin.lang.GLSLLanguage;
+import glslplugin.lang.elements.GLSLElement;
+
+import java.util.List;
+
+/**
+ * @author Darkyen
+ */
+public final class GLSLRedefinedTokenType extends IElementType {
+
+    private final List<PreprocessorToken> redefinedTo;
+
+    protected GLSLRedefinedTokenType(List<PreprocessorToken> redefinedTo) {
+        super("GLSLRedefinedToken", GLSLLanguage.GLSL_LANGUAGE, false);
+        this.redefinedTo = redefinedTo;
+    }
+
+    public static final class GLSLRedefinedPsiElement extends ASTWrapperPsiElement implements GLSLElement {
+
+        private final GLSLRedefinedTokenType type;
+
+        public GLSLRedefinedPsiElement(ASTNode node, GLSLRedefinedTokenType type) {
+            super(node);
+            this.type = type;
+        }
+
+        @Override
+        public <T extends GLSLElement> T findParentByClass(Class<T> clazz) {
+            return null;//TODO Impl
+        }
+
+        @Override
+        public GLSLElement findParentByClasses(Class<? extends GLSLElement>... clazzes) {
+            return null;//TODO Impl
+        }
+
+        @Override
+        public <T extends GLSLElement> T findPrevSiblingByClass(Class<T> clazz) {
+            return null;//TODO Impl
+        }
+
+        @Override
+        public GLSLElement findPrevSiblingByClasses(Class<? extends GLSLElement>... clazzes) {
+            return null;//TODO Impl
+        }
+
+        @Override
+        public boolean isDescendantOf(PsiElement ancestor) {
+            return false;//TODO Impl
+        }
+    }
+}

--- a/src/glslplugin/lang/parser/PreprocessorDropIn.java
+++ b/src/glslplugin/lang/parser/PreprocessorDropIn.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2010 Jean-Paul Balabanian and Yngve Devik Hammersland
+ *
+ *     This file is part of glsl4idea.
+ *
+ *     Glsl4idea is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as
+ *     published by the Free Software Foundation, either version 3 of
+ *     the License, or (at your option) any later version.
+ *
+ *     Glsl4idea is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package glslplugin.lang.parser;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Darkyen
+ */
+final class PreprocessorDropIn {
+    public final PreprocessorDropInType type;
+    public final List<PreprocessorToken> tokens;
+    public final String text;
+
+    private PreprocessorDropIn(PreprocessorDropInType type, List<PreprocessorToken> tokens) {
+        this.type = type;
+        this.tokens = tokens;
+        this.text = "";
+    }
+
+    PreprocessorDropIn(PreprocessorDropInType type, List<PreprocessorToken> tokens, String text) {
+        this.type = type;
+        this.tokens = tokens;
+        this.text = text;
+    }
+
+    public static final PreprocessorDropIn EMPTY = new PreprocessorDropIn(PreprocessorDropInType.EMPTY, Collections.<PreprocessorToken>emptyList());
+}

--- a/src/glslplugin/lang/parser/PreprocessorDropInType.java
+++ b/src/glslplugin/lang/parser/PreprocessorDropInType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010 Jean-Paul Balabanian and Yngve Devik Hammersland
+ *
+ *     This file is part of glsl4idea.
+ *
+ *     Glsl4idea is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as
+ *     published by the Free Software Foundation, either version 3 of
+ *     the License, or (at your option) any later version.
+ *
+ *     Glsl4idea is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package glslplugin.lang.parser;
+
+/**
+ * @author Darkyen
+ */
+enum PreprocessorDropInType {
+    /**
+     * Only part in constant_expression, which is needed when declaring arrays
+     */
+    CONDITIONAL_EXPRESSION,
+    EXPRESSION,
+    LITERAL,
+    /**
+     * When #define defines empty replacement
+     */
+    EMPTY,
+    UNKNOWN
+}

--- a/src/glslplugin/lang/parser/PreprocessorToken.java
+++ b/src/glslplugin/lang/parser/PreprocessorToken.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010 Jean-Paul Balabanian and Yngve Devik Hammersland
+ *
+ *     This file is part of glsl4idea.
+ *
+ *     Glsl4idea is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as
+ *     published by the Free Software Foundation, either version 3 of
+ *     the License, or (at your option) any later version.
+ *
+ *     Glsl4idea is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with glsl4idea.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package glslplugin.lang.parser;
+
+import com.intellij.psi.tree.IElementType;
+
+/**
+ * @author Darkyen
+ */
+class PreprocessorToken {
+    final IElementType type;
+    final String text;
+
+    public PreprocessorToken(IElementType type, CharSequence text) {
+        this.type = type;
+        this.text = text.toString();
+    }
+}

--- a/src/glslplugin/lang/scanner/GLSLFlexAdapter.java
+++ b/src/glslplugin/lang/scanner/GLSLFlexAdapter.java
@@ -23,6 +23,6 @@ import com.intellij.lexer.FlexAdapter;
 
 public class GLSLFlexAdapter extends FlexAdapter {
     public GLSLFlexAdapter() {
-        super(new GLSLFlexLexer((java.io.Reader) null));
+        super(new GLSLFlexLexer(null));
     }
 }

--- a/src/glslplugin/structureview/GLSLFileTreeElement.java
+++ b/src/glslplugin/structureview/GLSLFileTreeElement.java
@@ -55,14 +55,18 @@ class GLSLFileTreeElement extends GLSLStructureViewTreeElement<PsiFile> {
             for (PsiElement baseNode : baseNodes) {
                 if (baseNode instanceof GLSLVariableDeclaration) {
                     final GLSLVariableDeclaration declaration = (GLSLVariableDeclaration) baseNode;
-                    final GLSLTypedElement typedef = declaration.getTypeSpecifierNode().getTypeDefinition();
-                    if (typedef instanceof GLSLTypeDefinition) {
-                        final GLSLTypeDefinition definition = (GLSLTypeDefinition) typedef;
-                        definitions.add(definition);
-                    }
+                    final GLSLTypeSpecifier typeSpecifier = declaration.getTypeSpecifierNode();
 
-                    if (declaration.getDeclarators().length > 0) {
-                        variableDeclarations.add(declaration);
+                    if(typeSpecifier != null){
+                        final GLSLTypedElement typedef = typeSpecifier.getTypeDefinition();
+                        if (typedef instanceof GLSLTypeDefinition) {
+                            final GLSLTypeDefinition definition = (GLSLTypeDefinition) typedef;
+                            definitions.add(definition);
+                        }
+
+                        if (declaration.getDeclarators().length > 0) {
+                            variableDeclarations.add(declaration);
+                        }
                     }
                 } else if (baseNode instanceof GLSLFunctionDeclaration) {
                     functions.add((GLSLFunctionDeclaration) baseNode);

--- a/testfiles/PreprocessorTest.glsl
+++ b/testfiles/PreprocessorTest.glsl
@@ -1,0 +1,45 @@
+//This file should parse without errors
+
+#version 330
+
+#define INTERFAC buffer ShaderStorageBlock { mat4 projection; };
+
+INTERFAC
+// /\ should be hightlighted as replaced
+
+#define INTER buffer ShaderStorageBlock {
+#define FACE  mat4 projection; };
+
+INTER FACE
+//\ and /\ should get highlighted as replaced
+
+#define INTER1 buffer ShaderStorageBlock
+#define FACE1  { mat4 projection; };
+
+INTER1 FACE1
+//\ and /\ should get highlighted as replaced
+
+#define LOWP lowp
+
+LOWP float boo;
+
+#define FOO 3
+
+#define BAR FOO + 4
+
+int foobar = BAR;
+
+#define BAZ FOO + BAR * BAR + FOO * 6
+
+int baz = BAZ;
+
+#undef BAR
+
+int baaz = BAZ;
+
+#define Min(x,y) (x) < (y) ? (x):(y)
+
+void main(){
+	int i = Min(x,y);
+
+}

--- a/testfiles/PreprocessorTest.glsl
+++ b/testfiles/PreprocessorTest.glsl
@@ -1,4 +1,4 @@
-//This file should parse without errors
+//This file should parse without errors, except when noted
 
 #version 330
 
@@ -39,7 +39,24 @@ int baaz = BAZ;
 
 #define Min(x,y) (x) < (y) ? (x):(y)
 
-void main(){
+void functionDefineTest(){
+	//This should pass (..after adding support for function defines)
 	int i = Min(x,y);
+}
 
+#define ONE 1
+
+int one = ONE;
+
+#define VERDAD true
+
+void literalTypeTest(){
+	if(ONE){ //This should fail, because one is not boolean
+
+	}
+
+	//This should pass
+	if(VERDAD){
+
+	}
 }


### PR DESCRIPTION
### Overview of functionality
This adds support and highlighting for `#define` (and `#undef`).
It also makes all subclasses of GLSLElement much more robust and tolerant to malformed tree, which is easy to cause when creating more complex macros.

There is a special support when `#define` defines:
- literal - then it is even typechecked
- expression - then it is handled as opaque expression of unknown type
- nothing - then it is skipped by advanceLexer()

If it defines something else (anything), it will parse fine, tree should not get malformed, but GLSLElement-s won't be able to inspect themselves, because they will get mapped to unexpected token. That is why this PR makes them robust against that.

All* tokens which are redefined are highlighted as such and hovering over them will reveal what they are redefined as.

*There is a small bug, which is quite hard to hit and is not critical, that prevents highlighting of some tokens. See test file. Also, nested redefined tokens work, but are not highlighted yet.

### Technical
It was needed to rewrite a good amount of `GLSLParsing`'s utility methods and add a lot more code to them. So the `GLSLParsing` has been split to two: `GLSLParsingBase` which contains all utility methods, interfaces directly to PsiBuilder and deals with `#define` complexity, and `GLSLParsing`, which contains all grammar parsing code, as before. `GLSLParsing` extends `GLSLParsingBase` as only subclass. (No other class is intended to do that, ever).

Standard grammar-parsing methods no longer use PsiBuilder directly, all calls are routed through proxy methods, which handle tokens injected by redefined tokens automatically.

Redefining is only supported for `IDENTIFIER`s (= `#define 1 2` is not supported).