### PR TITLE
Fix issues with return types

### DIFF
--- a/src/glslplugin/annotation/impl/CheckReturnTypeAnnotation.java
+++ b/src/glslplugin/annotation/impl/CheckReturnTypeAnnotation.java
@@ -38,7 +38,7 @@ public class CheckReturnTypeAnnotation extends Annotator<GLSLStatement> {
                 GLSLType functionType = function.getTypeSpecifierNode().getType();
                 GLSLType returnType = ((GLSLReturnStatement) expr).getReturnType();
 
-                if (returnType.isValidType() && !functionType.isConvertibleTo(returnType)) {
+                if (returnType.isValidType() && !returnType.isConvertibleTo(functionType)) {
                     holder.createErrorAnnotation(expr, "Incompatible types. Required: " + functionType.getTypename() + ", found: " + returnType.getTypename());
                 }
             }

--- a/src/glslplugin/annotation/impl/CheckReturnTypeAnnotation.java
+++ b/src/glslplugin/annotation/impl/CheckReturnTypeAnnotation.java
@@ -38,7 +38,7 @@ public class CheckReturnTypeAnnotation extends Annotator<GLSLStatement> {
                 GLSLType functionType = function.getTypeSpecifierNode().getType();
                 GLSLType returnType = ((GLSLReturnStatement) expr).getReturnType();
 
-                if (!returnType.isValidType() || !functionType.isConvertibleTo(returnType)) {
+                if (returnType.isValidType() && !functionType.isConvertibleTo(returnType)) {
                     holder.createErrorAnnotation(expr, "Incompatible types. Required: " + functionType.getTypename() + ", found: " + returnType.getTypename());
                 }
             }


### PR DESCRIPTION
Previously, unknown return types were all marked as errors - this makes it a lot harder to spot real errors. (If expressions with unknown types should be considered errors, then it should be handled somewhere else, not just here.)

Also, return type conversion was backwards - the return expression type has to be convertible to the function's return type, not vice versa.