### PR TITLE
Implement rename and find usages

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -130,6 +130,7 @@
         <additionalTextAttributes scheme="Default" file="colorSchemes/GLSLDefault.xml"/>
         <additionalTextAttributes scheme="Darcula" file="colorSchemes/GLSLDarcula.xml"/>
         <lang.commenter language="GLSL" implementationClass="glslplugin.GLSLCommenter"/>
+        <lang.refactoringSupport language="GLSL" implementationClass="glslplugin.extensions.GLSLRefactoringSupportProvider" />
     </extensions>
 
     <application-components>

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -131,6 +131,7 @@
         <additionalTextAttributes scheme="Darcula" file="colorSchemes/GLSLDarcula.xml"/>
         <lang.commenter language="GLSL" implementationClass="glslplugin.GLSLCommenter"/>
         <lang.refactoringSupport language="GLSL" implementationClass="glslplugin.extensions.GLSLRefactoringSupportProvider" />
+        <lang.findUsagesProvider language="GLSL" implementationClass="glslplugin.extensions.GLSLFindUsagesProvider" />
     </extensions>
 
     <application-components>

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -132,6 +132,7 @@
         <lang.commenter language="GLSL" implementationClass="glslplugin.GLSLCommenter"/>
         <lang.refactoringSupport language="GLSL" implementationClass="glslplugin.extensions.GLSLRefactoringSupportProvider" />
         <lang.findUsagesProvider language="GLSL" implementationClass="glslplugin.extensions.GLSLFindUsagesProvider" />
+        <elementDescriptionProvider implementation="glslplugin.extensions.GLSLDescriptionProvider" />
     </extensions>
 
     <application-components>

--- a/src/glslplugin/annotation/impl/MemberCheckAnnotation.java
+++ b/src/glslplugin/annotation/impl/MemberCheckAnnotation.java
@@ -38,8 +38,7 @@ public class MemberCheckAnnotation extends Annotator<GLSLFieldSelectionExpressio
         if (leftHandType instanceof GLSLStructType) {
             GLSLIdentifier memberIdentifier = expr.getMemberIdentifier();
             if(memberIdentifier == null)return;
-
-            if (!leftHandType.hasMember(memberIdentifier.getIdentifierName())) {
+            if (!leftHandType.hasMember(memberIdentifier.getName())) {
                 holder.createErrorAnnotation(memberIdentifier, "Unknown member for " + leftHandType.getTypename());
             }
 

--- a/src/glslplugin/annotation/impl/ReservedIdentifierAnnotation.java
+++ b/src/glslplugin/annotation/impl/ReservedIdentifierAnnotation.java
@@ -12,7 +12,7 @@ public class ReservedIdentifierAnnotation extends Annotator<GLSLIdentifier> {
 
     @Override
     public void annotate(GLSLIdentifier identifier, AnnotationHolder holder) {
-        String name = identifier.getIdentifierName();
+        String name = identifier.getName();
         if (name.startsWith("__")) {
             holder.createWarningAnnotation(identifier, "This identifier is reserved for use by underlying software layers and may result in undefined behavior.");
         }

--- a/src/glslplugin/annotation/impl/VectorComponentsAnnotation.java
+++ b/src/glslplugin/annotation/impl/VectorComponentsAnnotation.java
@@ -48,7 +48,7 @@ public class VectorComponentsAnnotation extends Annotator<GLSLFieldSelectionExpr
             GLSLVectorType type = (GLSLVectorType) leftHandType;
             GLSLIdentifier memberIdentifier = expr.getMemberIdentifier();
             if(memberIdentifier == null)return;
-            String member = memberIdentifier.getIdentifierName();
+            String member = memberIdentifier.getName();
 
             if (!type.hasMember(member) && member.length() > 0) {
                 //It has no member like that, why?

--- a/src/glslplugin/extensions/GLSLDescriptionProvider.java
+++ b/src/glslplugin/extensions/GLSLDescriptionProvider.java
@@ -1,0 +1,40 @@
+package glslplugin.extensions;
+
+import com.intellij.psi.ElementDescriptionLocation;
+import com.intellij.psi.ElementDescriptionProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.usageView.UsageViewLongNameLocation;
+import com.intellij.usageView.UsageViewNodeTextLocation;
+import com.intellij.usageView.UsageViewTypeLocation;
+import glslplugin.lang.elements.declarations.GLSLDeclaration;
+import glslplugin.lang.elements.declarations.GLSLDeclarator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Created by abigail on 28/06/15.
+ */
+public class GLSLDescriptionProvider implements ElementDescriptionProvider {
+    @Override
+    @Nullable
+    public String getElementDescription(@NotNull PsiElement element, @NotNull ElementDescriptionLocation location) {
+        if (!(element instanceof GLSLDeclarator)) return null;
+        GLSLDeclarator declarator = (GLSLDeclarator) element;
+        GLSLDeclaration declaration = declarator.getParentDeclaration();
+        if (declaration == null) return null;
+
+        if (location instanceof UsageViewTypeLocation) {
+            return declaration.getDeclarationDescription();
+        }
+
+        if (location instanceof UsageViewLongNameLocation) {
+            return declaration.getDeclarationDescription() + " '" + declarator.getName() + "'";
+        }
+
+        if (location instanceof UsageViewNodeTextLocation) {
+            return declarator.getName();
+        }
+        return null;
+//        return location.toString();
+    }
+}

--- a/src/glslplugin/extensions/GLSLFindUsagesProvider.java
+++ b/src/glslplugin/extensions/GLSLFindUsagesProvider.java
@@ -1,0 +1,57 @@
+package glslplugin.extensions;
+
+import com.intellij.lang.cacheBuilder.DefaultWordsScanner;
+import com.intellij.lang.cacheBuilder.WordsScanner;
+import com.intellij.lang.findUsages.FindUsagesProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.tree.TokenSet;
+import glslplugin.lang.elements.GLSLTokenTypes;
+import glslplugin.lang.scanner.GLSLFlexAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Created by abigail on 26/06/15.
+ */
+public class GLSLFindUsagesProvider implements FindUsagesProvider {
+    private static final DefaultWordsScanner WORDS_SCANNER =
+            new DefaultWordsScanner(new GLSLFlexAdapter(),
+                    TokenSet.create(GLSLTokenTypes.IDENTIFIER),
+                    TokenSet.create(GLSLTokenTypes.COMMENT_LINE, GLSLTokenTypes.COMMENT_BLOCK),
+                    TokenSet.create(GLSLTokenTypes.PREPROCESSOR_STRING));
+    @Nullable
+    @Override
+    public WordsScanner getWordsScanner() {
+        return WORDS_SCANNER;
+    }
+
+    @Override
+    public boolean canFindUsagesFor(PsiElement psiElement) {
+        return psiElement instanceof PsiNamedElement;
+    }
+
+    @Nullable
+    @Override
+    public String getHelpId(PsiElement psiElement) {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public String getType(PsiElement element) {
+        return "GLSL Usage";
+    }
+
+    @NotNull
+    @Override
+    public String getDescriptiveName(@NotNull PsiElement element) {
+        return element.toString();
+    }
+
+    @NotNull
+    @Override
+    public String getNodeText(@NotNull PsiElement element, boolean useFullName) {
+        return element.toString();
+    }
+}

--- a/src/glslplugin/extensions/GLSLRefactoringSupportProvider.java
+++ b/src/glslplugin/extensions/GLSLRefactoringSupportProvider.java
@@ -1,0 +1,15 @@
+package glslplugin.extensions;
+
+import com.intellij.lang.refactoring.RefactoringSupportProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
+
+/**
+ * Created by abigail on 26/06/15.
+ */
+public class GLSLRefactoringSupportProvider extends RefactoringSupportProvider {
+    @Override
+    public boolean isMemberInplaceRenameAvailable(PsiElement element, PsiElement context) {
+        return element instanceof PsiNamedElement;
+    }
+}

--- a/src/glslplugin/intentions/Intentions.java
+++ b/src/glslplugin/intentions/Intentions.java
@@ -72,7 +72,7 @@ public abstract class Intentions extends PsiElementBaseIntentionAction {
         String completeFragment = "float " + value + ";";
         PsiElement newFile = createExpressionFromText(identifier, completeFragment);
         GLSLDeclarator[] glslDeclarators = ((GLSLVariableDeclaration) newFile.getFirstChild()).getDeclarators();
-        GLSLIdentifier result = glslDeclarators[0].getIdentifier();
+        GLSLIdentifier result = glslDeclarators[0].getNameIdentifier();
         assert result != null;
         return result;
     }

--- a/src/glslplugin/intentions/vectorcomponents/VectorComponentsPredicate.java
+++ b/src/glslplugin/intentions/vectorcomponents/VectorComponentsPredicate.java
@@ -48,7 +48,7 @@ public class VectorComponentsPredicate {
                     if(leftHandExpression == null)return false;
                     if (leftHandExpression.getType() instanceof GLSLVectorType) {
 
-                        String parameters = identifier.getIdentifierName();
+                        String parameters = identifier.getName();
                         if (checkForMatch(parameters)) {
                             return true;
                         }

--- a/src/glslplugin/lang/elements/GLSLIdentifier.java
+++ b/src/glslplugin/lang/elements/GLSLIdentifier.java
@@ -20,20 +20,48 @@
 package glslplugin.lang.elements;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiCheckedRenameElement;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
 import com.intellij.psi.PsiReference;
+import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class GLSLIdentifier extends GLSLElementImpl {
+public class GLSLIdentifier extends GLSLElementImpl implements PsiCheckedRenameElement, PsiNameIdentifierOwner {
 
     public GLSLIdentifier(@NotNull ASTNode astNode) {
         super(astNode);
     }
 
+    @Nullable
+    @Override
+    public PsiElement getNameIdentifier() {
+        return findChildByType(GLSLTokenTypes.IDENTIFIER);
+    }
+
     @NotNull
-    public String getIdentifierName() {
+    public String getName() {
         return getText();
+    }
+
+    @Override
+    public void checkSetName(String name) throws IncorrectOperationException {
+        final PsiElement oldName = getNameIdentifier();
+        if (oldName == null) throw new IncorrectOperationException("Unnamed identifier! (This probably shouldn't happen.)");
+        PsiElement newName = GLSLPsiElementFactory.createLeafElement(getProject(), name);
+        if (newName.getNode().getElementType() != GLSLTokenTypes.IDENTIFIER)
+            throw new IncorrectOperationException("Invalid identifier name!");
+    }
+
+    @Override
+    public PsiElement setName(@NotNull String name) throws IncorrectOperationException {
+        checkSetName(name);
+        final PsiElement oldName = getNameIdentifier();
+        assert oldName != null; // we've already checked this isn't null (and thrown if it is) in checkSetName
+        PsiElement newName = GLSLPsiElementFactory.createLeafElement(getProject(), name);
+        getNode().replaceChild(oldName.getNode(), newName.getNode());
+        return this;
     }
 
     @Nullable

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -20,7 +20,11 @@
 package glslplugin.lang.elements;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFileFactory;
 import com.intellij.psi.tree.IElementType;
+import glslplugin.GLSLSupportLoader;
 import glslplugin.lang.elements.declarations.*;
 import glslplugin.lang.elements.expressions.*;
 import glslplugin.lang.elements.preprocessor.GLSLEmptyDropIn;
@@ -28,6 +32,7 @@ import glslplugin.lang.elements.preprocessor.GLSLExpressionDropIn;
 import glslplugin.lang.elements.preprocessor.GLSLLiteralDropIn;
 import glslplugin.lang.elements.preprocessor.GLSLUnknownDropIn;
 import glslplugin.lang.elements.statements.*;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * GLSLPsiElementFactory defines the interface for the GLSLElement factory.
@@ -147,5 +152,13 @@ public class GLSLPsiElementFactory {
         if (type == GLSLElementTypes.STRUCT_DECLARATOR) return new GLSLDeclarator(node);
 
         return null;
+    }
+
+    @NotNull
+    public static PsiElement createLeafElement(Project project, String name) {
+        PsiElement element = PsiFileFactory.getInstance(project).
+                createFileFromText("dummy.glsl", GLSLSupportLoader.GLSL, name);
+        while (element.getFirstChild() != null) element = element.getFirstChild();
+        return element;
     }
 }

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaration.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaration.java
@@ -42,4 +42,7 @@ public interface GLSLDeclaration extends GLSLElement {
 
     @NotNull
     GLSLDeclarator[] getDeclarators();
+
+    @NotNull
+    String getDeclarationDescription();
 }

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclarationImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclarationImpl.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
  *         Date: Feb 2, 2009
  *         Time: 10:33:30 AM
  */
-public class GLSLDeclarationImpl extends GLSLElementImpl implements GLSLDeclaration {
+public abstract class GLSLDeclarationImpl extends GLSLElementImpl implements GLSLDeclaration {
     public GLSLDeclarationImpl(@NotNull ASTNode astNode) {
         super(astNode);
     }

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclarationImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclarationImpl.java
@@ -97,7 +97,7 @@ public class GLSLDeclarationImpl extends GLSLElementImpl implements GLSLDeclarat
             if (!first) {
                 b.append(", ");
             }
-            GLSLIdentifier identifier = declarator.getIdentifier();
+            GLSLIdentifier identifier = declarator.getNameIdentifier();
             if(identifier == null){
                 b.append("(unknown)");
             } else {

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclarationImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclarationImpl.java
@@ -101,7 +101,7 @@ public class GLSLDeclarationImpl extends GLSLElementImpl implements GLSLDeclarat
             if(identifier == null){
                 b.append("(unknown)");
             } else {
-                b.append(identifier.getIdentifierName());
+                b.append(identifier.getName());
             }
             first = false;
         }

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaratorBase.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaratorBase.java
@@ -54,7 +54,7 @@ public class GLSLDeclaratorBase extends GLSLElementImpl {
     public String getIdentifierName() {
         PsiElement idElement = getFirstChild();
         if (idElement instanceof GLSLIdentifier) {
-            return ((GLSLIdentifier) idElement).getIdentifierName();
+            return ((GLSLIdentifier) idElement).getName();
         } else {
             return "(anonymous)";
         }

--- a/src/glslplugin/lang/elements/declarations/GLSLDeclaratorBase.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLDeclaratorBase.java
@@ -21,6 +21,9 @@ package glslplugin.lang.elements.declarations;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.util.IncorrectOperationException;
 import glslplugin.lang.elements.GLSLElementImpl;
 import glslplugin.lang.elements.GLSLIdentifier;
 import glslplugin.lang.elements.types.*;
@@ -34,14 +37,15 @@ import org.jetbrains.annotations.Nullable;
  *         Date: Jan 27, 2009
  *         Time: 10:31:13 AM
  */
-public class GLSLDeclaratorBase extends GLSLElementImpl {
+public class GLSLDeclaratorBase extends GLSLElementImpl implements PsiNameIdentifierOwner {
 
     public GLSLDeclaratorBase(@NotNull ASTNode astNode) {
         super(astNode);
     }
 
+    @Override
     @Nullable
-    public GLSLIdentifier getIdentifier() {
+    public GLSLIdentifier getNameIdentifier() {
         PsiElement idElement = getFirstChild();
         if (idElement instanceof GLSLIdentifier) {
             return (GLSLIdentifier) idElement;
@@ -51,12 +55,22 @@ public class GLSLDeclaratorBase extends GLSLElementImpl {
     }
 
     @NotNull
-    public String getIdentifierName() {
-        PsiElement idElement = getFirstChild();
-        if (idElement instanceof GLSLIdentifier) {
-            return ((GLSLIdentifier) idElement).getName();
+    public String getName() {
+        GLSLIdentifier identifier = getNameIdentifier();
+        if (identifier != null) {
+            return identifier.getName();
         } else {
             return "(anonymous)";
+        }
+    }
+
+    @Override
+    public PsiElement setName(@NotNull String name) throws IncorrectOperationException {
+        GLSLIdentifier identifier = getNameIdentifier();
+        if (identifier != null) {
+            return identifier.setName(name);
+        } else {
+            throw new IncorrectOperationException("Declarator with no name!");
         }
     }
 
@@ -97,7 +111,7 @@ public class GLSLDeclaratorBase extends GLSLElementImpl {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        b.append("Declarator: ").append(getIdentifierName());
+        b.append("Declarator: ").append(getName());
         b.append(" : ").append(getType().getTypename());
         if (getType() instanceof GLSLArrayType) {
             b.append("[]");

--- a/src/glslplugin/lang/elements/declarations/GLSLFunctionDeclarationImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLFunctionDeclarationImpl.java
@@ -89,4 +89,10 @@ public class GLSLFunctionDeclarationImpl extends GLSLSingleDeclarationImpl imple
     private GLSLFunctionType createType() {
         return new GLSLBasicFunctionType(this);
     }
+
+    @NotNull
+    @Override
+    public String getDeclarationDescription() {
+        return "function";
+    }
 }

--- a/src/glslplugin/lang/elements/declarations/GLSLParameterDeclaration.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLParameterDeclaration.java
@@ -49,4 +49,10 @@ public class GLSLParameterDeclaration extends GLSLSingleDeclarationImpl {
         }
         return b.toString();
     }
+
+    @NotNull
+    @Override
+    public String getDeclarationDescription() {
+        return "parameter";
+    }
 }

--- a/src/glslplugin/lang/elements/declarations/GLSLSingleDeclarationImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLSingleDeclarationImpl.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
  *         Date: Feb 2, 2009
  *         Time: 12:46:15 PM
  */
-public class GLSLSingleDeclarationImpl extends GLSLDeclarationImpl implements GLSLSingleDeclaration {
+public abstract class GLSLSingleDeclarationImpl extends GLSLDeclarationImpl implements GLSLSingleDeclaration {
     public GLSLSingleDeclarationImpl(@NotNull ASTNode astNode) {
         super(astNode);
     }

--- a/src/glslplugin/lang/elements/declarations/GLSLSingleDeclarationImpl.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLSingleDeclarationImpl.java
@@ -41,7 +41,7 @@ public class GLSLSingleDeclarationImpl extends GLSLDeclarationImpl implements GL
         if(declarator == null){
             return "(unknown)";
         }else{
-            return declarator.getIdentifierName();
+            return declarator.getName();
         }
     }
 

--- a/src/glslplugin/lang/elements/declarations/GLSLStructDeclaration.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLStructDeclaration.java
@@ -21,7 +21,6 @@ package glslplugin.lang.elements.declarations;
 
 import org.jetbrains.annotations.NotNull;
 import com.intellij.lang.ASTNode;
-import glslplugin.lang.elements.declarations.GLSLDeclarationImpl;
 
 /**
  * NewStructDeclaration is ...
@@ -38,5 +37,11 @@ public class GLSLStructDeclaration extends GLSLDeclarationImpl {
     @Override
     public String toString() {
         return "Struct Declaration: " + getDeclaratorsString();
+    }
+
+    @NotNull
+    @Override
+    public String getDeclarationDescription() {
+        return "struct member";
     }
 }

--- a/src/glslplugin/lang/elements/declarations/GLSLTypeDefinition.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLTypeDefinition.java
@@ -117,7 +117,7 @@ public class GLSLTypeDefinition extends GLSLElementImpl implements GLSLTypedElem
     @Nullable
     public GLSLDeclarator getDeclarator(@NotNull String name) {
         for (GLSLDeclarator declarator : getDeclarators()) {
-            if (name.equals(declarator.getIdentifierName())) {
+            if (name.equals(declarator.getName())) {
                 return declarator;
             }
         }

--- a/src/glslplugin/lang/elements/declarations/GLSLTypeDefinition.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLTypeDefinition.java
@@ -55,7 +55,7 @@ public class GLSLTypeDefinition extends GLSLElementImpl implements GLSLTypedElem
         if (children.length > 1) {
             PsiElement id = children[0];
             if (id instanceof GLSLIdentifier) {
-                return ((GLSLIdentifier) id).getIdentifierName();
+                return ((GLSLIdentifier) id).getName();
             }
         }
         return null;

--- a/src/glslplugin/lang/elements/declarations/GLSLVariableDeclaration.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLVariableDeclaration.java
@@ -19,9 +19,9 @@
 
 package glslplugin.lang.elements.declarations;
 
+import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import com.intellij.lang.ASTNode;
-import glslplugin.lang.elements.declarations.GLSLDeclarationImpl;
 
 /**
  * NewVariableDeclaration is ...
@@ -38,5 +38,14 @@ public class GLSLVariableDeclaration extends GLSLDeclarationImpl {
     @Override
     public String toString() {
         return "Variable Declaration: " + getDeclaratorsString();
+    }
+
+    @NotNull
+    @Override
+    public String getDeclarationDescription() {
+        if (PsiTreeUtil.getParentOfType(this, GLSLFunctionDefinition.class) != null) {
+            return "local variable";
+        }
+        return "global variable";
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLFieldSelectionExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLFieldSelectionExpression.java
@@ -70,7 +70,7 @@ public class GLSLFieldSelectionExpression extends GLSLSelectionExpressionBase im
                 //If any of the components are repeated, it is not a L value
                 GLSLIdentifier memberIdentifier = getMemberIdentifier();
                 if(memberIdentifier == null)return true; //This should not happen
-                String components = memberIdentifier.getIdentifierName();
+                String components = memberIdentifier.getName();
                 for (int i = 0; i < components.length(); i++) {
                     char c = components.charAt(i);
                     for (int j = i+1; j < components.length(); j++) {
@@ -99,7 +99,7 @@ public class GLSLFieldSelectionExpression extends GLSLSelectionExpressionBase im
         if(!leftHandType.isValidType())return false;
         if(!(leftHandType instanceof GLSLVectorType))return false;
         //If it got here, it is picking a component(s) from a vector. But how many?
-        return memberIdentifier.getIdentifierName().length() > 1;
+        return memberIdentifier.getName().length() > 1;
         //Because all vector components are marked as only one letter, having more letters means swizzling
     }
 
@@ -126,7 +126,7 @@ public class GLSLFieldSelectionExpression extends GLSLSelectionExpressionBase im
             if(memberIdentifier == null){
                 return null;
             }else{
-                return ((GLSLTypeDefinition) definition).getDeclarator(memberIdentifier.getIdentifierName());
+                return ((GLSLTypeDefinition) definition).getDeclarator(memberIdentifier.getName());
             }
         } else {
             return null;
@@ -152,7 +152,7 @@ public class GLSLFieldSelectionExpression extends GLSLSelectionExpressionBase im
             }
             GLSLIdentifier memberIdentifier = getMemberIdentifier();
             if(memberIdentifier == null)return GLSLTypes.UNKNOWN_TYPE;
-            else return type.getMemberType(memberIdentifier.getIdentifierName());
+            else return type.getMemberType(memberIdentifier.getName());
         }
     }
 
@@ -161,7 +161,7 @@ public class GLSLFieldSelectionExpression extends GLSLSelectionExpressionBase im
         if(memberIdentifier == null){
             return "Field selection: '(unknown)'";
         }else{
-            return "Field selection: '" + memberIdentifier.getIdentifierName() + "'";
+            return "Field selection: '" + memberIdentifier.getName() + "'";
         }
     }
 }

--- a/src/glslplugin/lang/elements/expressions/GLSLFunctionCallExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLFunctionCallExpression.java
@@ -61,7 +61,7 @@ public class GLSLFunctionCallExpression extends GLSLExpression implements GLSLRe
     public String getFunctionName() {
         GLSLIdentifier identifier = getFunctionNameIdentifier();
         if(identifier != null){
-            return identifier.getIdentifierName();
+            return identifier.getName();
         }else{
             return "(unknown)";
         }

--- a/src/glslplugin/lang/elements/expressions/GLSLIdentifierExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLIdentifierExpression.java
@@ -21,6 +21,9 @@ package glslplugin.lang.elements.expressions;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.util.IncorrectOperationException;
 import glslplugin.lang.elements.GLSLIdentifier;
 import glslplugin.lang.elements.GLSLReferenceElement;
 import glslplugin.lang.elements.declarations.*;
@@ -39,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
  *         Date: Feb 4, 2009
  *         Time: 12:16:41 AM
  */
-public class GLSLIdentifierExpression extends GLSLExpression implements GLSLReferenceElement {
+public class GLSLIdentifierExpression extends GLSLExpression implements GLSLReferenceElement, PsiNameIdentifierOwner {
     public GLSLIdentifierExpression(@NotNull ASTNode astNode) {
         super(astNode);
     }
@@ -50,13 +53,15 @@ public class GLSLIdentifierExpression extends GLSLExpression implements GLSLRefe
         return true;
     }
 
+    @Override
     @Nullable
-    public GLSLIdentifier getIdentifier() {
+    public GLSLIdentifier getNameIdentifier() {
         return findChildByClass(GLSLIdentifier.class);
     }
 
-    public String getIdentifierName() {
-        GLSLIdentifier identifier = getIdentifier();
+    @Override
+    public String getName() {
+        GLSLIdentifier identifier = getNameIdentifier();
         if(identifier != null){
             return identifier.getName();
         }else{
@@ -65,8 +70,18 @@ public class GLSLIdentifierExpression extends GLSLExpression implements GLSLRefe
     }
 
     @Override
+    public PsiElement setName(@NotNull String name) throws IncorrectOperationException {
+        GLSLIdentifier identifier = getNameIdentifier();
+        if (identifier != null) {
+            return identifier.setName(name);
+        } else {
+            throw new IncorrectOperationException("Declarator with no name!");
+        }
+    }
+
+    @Override
     public String toString() {
-        return "Identifier Expression: " + getIdentifierName();
+        return "Identifier Expression: " + getName();
     }
 
     @NotNull
@@ -148,7 +163,7 @@ public class GLSLIdentifierExpression extends GLSLExpression implements GLSLRefe
     @Nullable
     private GLSLDeclarator getVariableReferenceCheckDeclaration(GLSLDeclaration declaration) {
         for (GLSLDeclarator declarator : declaration.getDeclarators()) {
-            if (declarator.getIdentifierName().equals(getIdentifierName())) {
+            if (declarator.getName().equals(getName())) {
                 return declarator;
             }
         }

--- a/src/glslplugin/lang/elements/expressions/GLSLIdentifierExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLIdentifierExpression.java
@@ -58,7 +58,7 @@ public class GLSLIdentifierExpression extends GLSLExpression implements GLSLRefe
     public String getIdentifierName() {
         GLSLIdentifier identifier = getIdentifier();
         if(identifier != null){
-            return identifier.getIdentifierName();
+            return identifier.getName();
         }else{
             return "(unknown)";
         }

--- a/src/glslplugin/lang/elements/expressions/GLSLMethodCallExpression.java
+++ b/src/glslplugin/lang/elements/expressions/GLSLMethodCallExpression.java
@@ -54,7 +54,7 @@ public class GLSLMethodCallExpression extends GLSLSelectionExpressionBase {
     public String getMethodName() {
         GLSLIdentifier methodIdentifier = getMethodIdentifier();
         if(methodIdentifier != null){
-            return methodIdentifier.getIdentifierName();
+            return methodIdentifier.getName();
         }else{
             return "(unknown)";
         }

--- a/src/glslplugin/lang/elements/reference/GLSLReferenceBase.java
+++ b/src/glslplugin/lang/elements/reference/GLSLReferenceBase.java
@@ -21,6 +21,7 @@ package glslplugin.lang.elements.reference;
 
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.util.IncorrectOperationException;
 import glslplugin.lang.elements.GLSLElement;
@@ -62,6 +63,9 @@ public abstract class GLSLReferenceBase<SOURCE_TYPE extends GLSLElement, TARGET_
     }
 
     public PsiElement handleElementRename(String newElementName) throws IncorrectOperationException {
+        if (source instanceof PsiNamedElement) {
+            return ((PsiNamedElement) source).setName(newElementName);
+        }
         throw new IncorrectOperationException("Not supported!");
     }
 
@@ -70,7 +74,7 @@ public abstract class GLSLReferenceBase<SOURCE_TYPE extends GLSLElement, TARGET_
     }
 
     public boolean isReferenceTo(PsiElement element) {
-        return false;
+        return element == resolve();
     }
 
     @NotNull

--- a/src/glslplugin/lang/elements/types/GLSLStructType.java
+++ b/src/glslplugin/lang/elements/types/GLSLStructType.java
@@ -50,7 +50,7 @@ public final class GLSLStructType extends GLSLType {
 
         for (int i = 0; i < declarators.length; i++) {
             final GLSLDeclarator declarator = declarators[i];
-            members.put(declarator.getIdentifierName(), declarator.getType());
+            members.put(declarator.getName(), declarator.getType());
             memberTypes[i] = declarator.getType();
         }
 

--- a/src/glslplugin/structureview/GLSLPresentation.java
+++ b/src/glslplugin/structureview/GLSLPresentation.java
@@ -84,7 +84,7 @@ class GLSLPresentation implements ItemPresentation {
     public static GLSLPresentation createFieldPresentation(String type, GLSLDeclarator[] declarators) {
         String dec = prettyPrint(stringify(declarators, new Stringifyer<GLSLDeclarator>() {
             public String stringify(GLSLDeclarator glslDeclarator) {
-                GLSLIdentifier identifier = glslDeclarator.getIdentifier();
+                GLSLIdentifier identifier = glslDeclarator.getNameIdentifier();
                 if(identifier == null)return "(unknown)";
                 else return identifier.getName();
             }
@@ -127,7 +127,7 @@ class GLSLPresentation implements ItemPresentation {
             result += " ";
         }
 
-        result += declarator.getIdentifierName();
+        result += declarator.getName();
 
         result += " : ";
         result += type.getType().getTypename();

--- a/src/glslplugin/structureview/GLSLPresentation.java
+++ b/src/glslplugin/structureview/GLSLPresentation.java
@@ -86,7 +86,7 @@ class GLSLPresentation implements ItemPresentation {
             public String stringify(GLSLDeclarator glslDeclarator) {
                 GLSLIdentifier identifier = glslDeclarator.getIdentifier();
                 if(identifier == null)return "(unknown)";
-                else return identifier.getIdentifierName();
+                else return identifier.getName();
             }
         }));
         GLSLPresentation presentation = new GLSLPresentation(dec + " : " + type);


### PR DESCRIPTION
Implements #4 and #5 to some extent.

This isn't a perfect approach. The existing `GLSLReferenceBase` objects should ideally all be references to a `PsiNamedElement` (if it's referencing something which *has* a name), and it was easier to make declarators and identifier expressions implement that than it was to fix up where the references point to.