### PR TITLE
Correctly parse preprocessor-directive-only files

### DIFF
--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -29,7 +29,6 @@ import org.jetbrains.annotations.NotNull;
 
 public class GLSLElementTypes {
     public static final IFileElementType FILE = new IFileElementType(Language.findInstance(GLSLLanguage.class));
-    public static final IElementType TRANSLATION_UNIT = new GLSLElementType("TRANSLATION_UNIT");
     public static final IElementType BLOCK = new GLSLElementType("BLOCK");
 
     public static final IElementType PREPROCESSOR_DIRECTIVE = new GLSLElementType("PREPROCESSOR_DIRECTIVE");

--- a/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
+++ b/src/glslplugin/lang/elements/GLSLPsiElementFactory.java
@@ -64,9 +64,6 @@ public class GLSLPsiElementFactory {
             return new GLSLUnknownDropIn(node, t.text);
         }
 
-        // translation unit
-        if (type == GLSLElementTypes.TRANSLATION_UNIT) return new GLSLTranslationUnit(node);
-
         // primary expressions
         if (type == GLSLElementTypes.VARIABLE_NAME_EXPRESSION) return new GLSLIdentifierExpression(node);
         if (type == GLSLElementTypes.CONSTANT_EXPRESSION) return new GLSLLiteral(node);

--- a/src/glslplugin/lang/parser/GLSLParsing.java
+++ b/src/glslplugin/lang/parser/GLSLParsing.java
@@ -191,9 +191,7 @@ public final class GLSLParsing extends GLSLParsingBase {
      * Entry for parser. Tries to parse whole shader file.
      */
     public void parseTranslationUnit() {
-        // translation_unit: external_declaration+
-
-        PsiBuilder.Marker unit = mark();
+        // translation_unit: external_declaration*
 
         // We normally parse preprocessor directives whenever we advance the lexer - which means that if the first
         // token is a preprocessor directive we won't catch it, so we just parse them all at the beginning here.
@@ -201,14 +199,12 @@ public final class GLSLParsing extends GLSLParsingBase {
             parsePreprocessor();
         }
 
-        do {
+        while (!isEof()) {
             if (!parseExternalDeclaration()) {
                 advanceLexer();
                 error("Unable to parse external declaration.");
             }
         }
-        while (!isEof());
-        unit.done(TRANSLATION_UNIT);
     }
 
     /**


### PR DESCRIPTION
Also remove the translation unit PSI node, as it serves no purpose (and CLion doesn't use one).