### PR TITLE
Update struct type members on struct subtree change

### DIFF
--- a/src/glslplugin/lang/elements/declarations/GLSLTypeDefinition.java
+++ b/src/glslplugin/lang/elements/declarations/GLSLTypeDefinition.java
@@ -132,4 +132,17 @@ public class GLSLTypeDefinition extends GLSLElementImpl implements GLSLTypedElem
         if (identifier == null) return null;
         return identifier.setName(name);
     }
+
+
+    /**
+     * Update type's cached members if the struct's subtree changes.
+     */
+    @Override
+    public void subtreeChanged() {
+        super.subtreeChanged();
+
+        if (type != null) {
+            type.updateMembers();
+        }
+    }
 }

--- a/src/glslplugin/lang/elements/types/GLSLStructType.java
+++ b/src/glslplugin/lang/elements/types/GLSLStructType.java
@@ -38,28 +38,35 @@ public final class GLSLStructType extends GLSLType {
     private final GLSLTypeDefinition definition;
     private final String typename;
     private final Map<String, GLSLType> members = new HashMap<String, GLSLType>();
-    private final GLSLFunctionType[] constructors;
+    private final GLSLFunctionType[] constructors = new GLSLFunctionType[1];
 
     public GLSLStructType(GLSLTypeDefinition definition) {
         super(null);
         this.definition = definition;
-        final GLSLDeclarator[] declarators = definition.getDeclarators();
 
         typename = definition.getName() != null
                         ? definition.getName()
                         : "(anonymous " + System.identityHashCode(this) + ")";
 
+        updateMembers();
+    }
+
+    /**
+     * Updates internal members containers from the struct type definition.
+     */
+    public void updateMembers() {
+        final GLSLDeclarator[] declarators = definition.getDeclarators();
+
         GLSLType[] memberTypes = new GLSLType[declarators.length];
 
+        members.clear();
         for (int i = 0; i < declarators.length; i++) {
             final GLSLDeclarator declarator = declarators[i];
             members.put(declarator.getName(), declarator.getType());
             memberTypes[i] = declarator.getType();
         }
 
-        constructors = new GLSLFunctionType[]{
-                new GLSLBasicFunctionType(getTypename(), this, memberTypes)
-        };
+        constructors[0] = new GLSLBasicFunctionType(getTypename(), this, memberTypes);
     }
 
     @NotNull


### PR DESCRIPTION
Currently struct changes stay cached awfully long (even over file reopening). This change updates cached members every time the struct subtree changes.

I'm not sure if there's better way to get structural subtree changes than subtreeChanged(), which seems to get called even on whitespace changes.