### PR TITLE
Fix constructor param count breaking on unknown types

### DIFF
--- a/testfiles/AnnotatorTest.glsl
+++ b/testfiles/AnnotatorTest.glsl
@@ -70,6 +70,8 @@ void VectorConstructorParamCountAnnotation(){
     v3 = vec3(vec4(1));
     v4 = vec4(1, vec4(1));
     v3 = vec3(vec3(1), 1);//Should warn here
+
+    v3 = vec3(1.0, 1.0, someParameterWithUnknownType);
 }
 
 //Unreachable Annotation


### PR DESCRIPTION
Eg. `vec3(1.0, cos(1.0), 1.0)` would break because the cosine function return type cannot be resolved in compile time (yet!)