### PR TITLE
Add vector component completion

### DIFF
--- a/src/glslplugin/extensions/GLSLCompletionContributor.java
+++ b/src/glslplugin/extensions/GLSLCompletionContributor.java
@@ -24,14 +24,21 @@ import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementPresentation;
 import com.intellij.patterns.ElementPattern;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.ProcessingContext;
 import glslplugin.GLSLSupportLoader;
 import glslplugin.lang.elements.GLSLIdentifier;
+import glslplugin.lang.elements.declarations.GLSLDeclarator;
+import glslplugin.lang.elements.expressions.GLSLAssignmentExpression;
 import glslplugin.lang.elements.expressions.GLSLExpression;
 import glslplugin.lang.elements.expressions.GLSLFieldSelectionExpression;
+import glslplugin.lang.elements.types.GLSLScalarType;
 import glslplugin.lang.elements.types.GLSLStructType;
 import glslplugin.lang.elements.types.GLSLType;
+import glslplugin.lang.elements.types.GLSLVectorType;
+import glslplugin.util.VectorComponents;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
@@ -56,10 +63,25 @@ public class GLSLCompletionContributor extends DefaultCompletionContributor {
                 GLSLExpression leftHandExpression = fieldSelection.getLeftHandExpression();
                 if (leftHandExpression == null) return;
 
-                // Only complete struct types for now
+                // Struct member completion
                 GLSLType type = leftHandExpression.getType();
                 if (type instanceof GLSLStructType) {
                     completeStructTypes(((GLSLStructType) type), completionResultSet);
+                }
+
+                // Vector completion that infers component count from the context
+                if (type instanceof GLSLVectorType) {
+                    // if it's a declaration (eg. `vec3 v3 = v4.`) the context type is inferred from declarator type (here vec3)
+                    GLSLDeclarator declarator = PsiTreeUtil.getParentOfType(fieldSelection, GLSLDeclarator.class);
+                    if (declarator != null) {
+                        completeVectorTypes(((GLSLVectorType) type), declarator.getType(), completionResultSet);
+                    }
+
+                    // if it's an assignment (eg. `vec3 v3; v3 = v4.`) the context type is inferred from variable type (if known)
+                    GLSLAssignmentExpression assignment = PsiTreeUtil.getParentOfType(fieldSelection, GLSLAssignmentExpression.class);
+                    if (assignment != null) {
+                        completeVectorTypes(((GLSLVectorType) type), assignment.getType(), completionResultSet);
+                    }
                 }
             }
         });
@@ -70,6 +92,31 @@ public class GLSLCompletionContributor extends DefaultCompletionContributor {
             completionResultSet.addElement(new GLSLLookupElement(entry.getKey(), entry.getValue()));
         }
         completionResultSet.stopHere();
+    }
+
+    /**
+     * Vector type completion implementation. Uses values from {@link VectorComponents} in order.
+     *
+     * @param type the vector type we're completing
+     * @param contextNumComponents how many components does the context expect
+     * @param completionResultSet
+     */
+    private void completeVectorTypes(GLSLVectorType type, int contextNumComponents, CompletionResultSet completionResultSet) {
+        int componentCount = Math.min(contextNumComponents, type.getNumComponents());
+
+        for (VectorComponents components : VectorComponents.values()) {
+            completionResultSet.addElement(new GLSLLookupElement(components.getComponentRange(componentCount), type));
+        }
+
+        completionResultSet.stopHere();
+    }
+
+    private void completeVectorTypes(GLSLVectorType type, @Nullable GLSLType contextType, CompletionResultSet completionResultSet) {
+        if (contextType instanceof GLSLScalarType) {
+            completeVectorTypes(type, 1, completionResultSet);
+        } else if (contextType instanceof GLSLVectorType) {
+            completeVectorTypes(type, ((GLSLVectorType) contextType).getNumComponents(), completionResultSet);
+        }
     }
 
     public static class GLSLLookupElement extends LookupElement {

--- a/src/glslplugin/intentions/vectorcomponents/VectorComponentsIntention.java
+++ b/src/glslplugin/intentions/vectorcomponents/VectorComponentsIntention.java
@@ -28,27 +28,12 @@ import com.intellij.psi.PsiElement;
 import com.intellij.ui.components.JBList;
 import glslplugin.intentions.Intentions;
 import glslplugin.lang.elements.GLSLIdentifier;
+import glslplugin.util.VectorComponents;
 import org.jetbrains.annotations.NotNull;
 
 import static glslplugin.intentions.vectorcomponents.VectorComponentsPredicate.*;
 
 public class VectorComponentsIntention extends Intentions {
-
-    private enum Components {
-        RGBA("rgba"),
-        XYZW("xyzw"),
-        STPQ("stpq");
-
-        private String components;
-
-        Components(String components) {
-            this.components = components;
-        }
-
-        public String getComponent(int i) {
-            return String.valueOf(components.charAt(i));
-        }
-    }
 
     private String[] results = new String[2];
 
@@ -110,15 +95,15 @@ public class VectorComponentsIntention extends Intentions {
     private void createComponentVariants(String components) {
         int i = 0;
         if (!rgba.matcher(components).matches()) {
-            results[i++] = convertComponents(components, Components.RGBA);
+            results[i++] = convertComponents(components, VectorComponents.RGBA);
         }
 
         if (!xyzw.matcher(components).matches()) {
-            results[i++] = convertComponents(components, Components.XYZW);
+            results[i++] = convertComponents(components, VectorComponents.XYZW);
         }
 
         if (!stpq.matcher(components).matches()) {
-            results[i++] = convertComponents(components, Components.STPQ);
+            results[i++] = convertComponents(components, VectorComponents.STPQ);
         }
 
         if (i != 2) {
@@ -126,7 +111,7 @@ public class VectorComponentsIntention extends Intentions {
         }
     }
 
-    private String convertComponents(String vectorComponents, Components components) {
+    private String convertComponents(String vectorComponents, VectorComponents components) {
         return toComponents(toNumbers(vectorComponents), components);
     }
 
@@ -138,7 +123,7 @@ public class VectorComponentsIntention extends Intentions {
         return results;
     }
 
-    private String toComponents(String componentsAsNumbers, Components components) {
+    private String toComponents(String componentsAsNumbers, VectorComponents components) {
         String results = componentsAsNumbers.replaceAll("1", components.getComponent(0));
         results = results.replaceAll("2", components.getComponent(1));
         results = results.replaceAll("3", components.getComponent(2));

--- a/src/glslplugin/util/VectorComponents.java
+++ b/src/glslplugin/util/VectorComponents.java
@@ -1,0 +1,27 @@
+package glslplugin.util;
+
+public enum VectorComponents {
+    XYZW("xyzw"),
+    RGBA("rgba"),
+    STPQ("stpq");
+
+    private String components;
+
+    VectorComponents(String components) {
+        this.components = components;
+    }
+
+    public String getComponent(int i) {
+        return String.valueOf(components.charAt(i));
+    }
+
+    /**
+     * Returns list of components from 0 to end (exclusive). If end > components length, clamps to components length.
+     *
+     * @param end
+     * @return
+     */
+    public String getComponentRange(int end) {
+        return components.substring(0, Math.min(end, components.length()));
+    }
+}


### PR DESCRIPTION
There is probably a better way to do the context type inferring (which in this implementation fails for expressions such as `vec4 v4 = vec4(vec3(someOtherVec.[caret]));`) but I don't know of it. If you know of such thing I could modify the code to use that instead.
