### PR TITLE
Folding of preprocessor if blocks. 

### DIFF
--- a/src/glslplugin/GLSLFoldingBuilder.java
+++ b/src/glslplugin/GLSLFoldingBuilder.java
@@ -25,6 +25,8 @@ import com.intellij.lang.folding.FoldingDescriptor;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
+import glslplugin.lang.elements.GLSLElementType;
 import glslplugin.lang.elements.GLSLElementTypes;
 import glslplugin.lang.elements.GLSLTokenTypes;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +35,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class GLSLFoldingBuilder implements FoldingBuilder {
+    private static final TokenSet FOLDABLE_ELEMENTS = TokenSet.create(
+            GLSLTokenTypes.COMMENT_BLOCK,
+            GLSLElementTypes.COMPOUND_STATEMENT,
+            GLSLElementTypes.PREPROCESSOR_CONDITIONAL_BLOCK
+    );
 
     @NotNull
     public FoldingDescriptor[] buildFoldRegions(@NotNull ASTNode node, @NotNull Document document) {
@@ -48,7 +55,7 @@ public class GLSLFoldingBuilder implements FoldingBuilder {
         //Don't add folding to 0-length nodes, crashes in new FoldingDescriptor
         if(textRange.getLength() <= 0)return;
 
-        if (type == GLSLTokenTypes.COMMENT_BLOCK || type == GLSLElementTypes.COMPOUND_STATEMENT) {
+        if (FOLDABLE_ELEMENTS.contains(type)) {
             descriptors.add(new FoldingDescriptor(node, textRange));
         }
 
@@ -60,10 +67,11 @@ public class GLSLFoldingBuilder implements FoldingBuilder {
     }
 
     public String getPlaceholderText(@NotNull ASTNode node) {
-        if (node.getElementType() == GLSLTokenTypes.COMMENT_BLOCK) {
+        final IElementType type = node.getElementType();
+        if (type == GLSLTokenTypes.COMMENT_BLOCK) {
             return "/*...*/";
         }
-        if (node.getElementType() == GLSLElementTypes.COMPOUND_STATEMENT) {
+        if (type == GLSLElementTypes.COMPOUND_STATEMENT || type == GLSLElementTypes.PREPROCESSOR_CONDITIONAL_BLOCK) {
             return "{...}";
         }
         return null;

--- a/src/glslplugin/lang/elements/GLSLElementTypes.java
+++ b/src/glslplugin/lang/elements/GLSLElementTypes.java
@@ -114,6 +114,12 @@ public class GLSLElementTypes {
 
     public static final IElementType CONDITION = new GLSLElementType("CONDITION");
 
+    /**
+     * Single {@code PREPROCESSOR_CONDITIONAL_BLOCK} is formed between each respective pair of {@link GLSLTokenTypes#PREPROCESSOR_CONDITIONAL_BLOCK_BEGIN}
+     * and {@link GLSLTokenTypes#PREPROCESSOR_CONDITIONAL_BLOCK_END} tokens.
+     */
+    public static final IElementType PREPROCESSOR_CONDITIONAL_BLOCK = new GLSLElementType("PREPROCESSOR_CONDITIONAL_BLOCK");
+
     //Preprocessor dropins
     public static final class RedefinedTokenElementType extends GLSLElementType {
 

--- a/src/glslplugin/lang/elements/GLSLTokenTypes.java
+++ b/src/glslplugin/lang/elements/GLSLTokenTypes.java
@@ -233,6 +233,20 @@ public class GLSLTokenTypes {
             PREPROCESSOR_CONCAT,
             PREPROCESSOR_OTHER);
 
+    public static final TokenSet PREPROCESSOR_CONDITIONAL_BLOCK_BEGIN = TokenSet.create(
+            PREPROCESSOR_IF,
+            PREPROCESSOR_IFDEF,
+            PREPROCESSOR_IFNDEF,
+            PREPROCESSOR_ELIF,
+            PREPROCESSOR_ELSE
+    );
+
+    public static final TokenSet PREPROCESSOR_CONDITIONAL_BLOCK_END = TokenSet.create(
+            PREPROCESSOR_ELSE,
+            PREPROCESSOR_ELIF,
+            PREPROCESSOR_ENDIF
+    );
+
     // Type specifiers
     public static final TokenSet FLOAT_TYPE_SPECIFIER_NONARRAY = TokenSet.create(
             FLOAT_TYPE, VEC2_TYPE, VEC3_TYPE, VEC4_TYPE,

--- a/src/glslplugin/lang/parser/GLSLParsingBase.java
+++ b/src/glslplugin/lang/parser/GLSLParsingBase.java
@@ -27,6 +27,7 @@ import com.intellij.psi.tree.TokenSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 
 import static glslplugin.lang.elements.GLSLElementTypes.*;
 import static glslplugin.lang.elements.GLSLTokenTypes.*;
@@ -48,6 +49,7 @@ abstract class GLSLParsingBase {
 
     protected Map<String, List<ForeignLeafType>> definitions = new HashMap<>();
     protected Map<String, String> definitionTexts = new HashMap<>();
+    protected Stack<PsiBuilder.Marker> preprocessorConditionalBlockMarkers = new Stack<>();
 
     GLSLParsingBase(PsiBuilder builder) {
         b = new GLSLPsiBuilderAdapter(builder);


### PR DESCRIPTION
Partfixes #139.

Works against my testfile, which was `resources/environment/builtin.tese`. Might require workarounds as in GLSLParsing past line 290 in my commit for other cases, as preprocessor handling is somewhat broken for these cases. I might be able to test that myself, but no sooner than tomorrow afternoon, if you happened to know if there are any more such quirks as the one I noticed, or if there is an easier workaround, it would be appreciated.