### PR TITLE
Fix for parsing errors when using "empty" definitions nested

### DIFF
--- a/src/main/java/glslplugin/lang/parser/PreprocessorPsiBuilderAdapter.java
+++ b/src/main/java/glslplugin/lang/parser/PreprocessorPsiBuilderAdapter.java
@@ -132,13 +132,15 @@ public class PreprocessorPsiBuilderAdapter {
             parent.remapCurrentToken(GLSLTokenTypes.PREPROCESSOR_REDEFINED);
             parent.advanceLexer();
 
-            if (redefinition.redefinedTo.isEmpty()) {
-                result.add(new ForeignLeafType(GLSLTokenTypes.PREPROCESSOR_REDEFINED, ""));
-            }
-
             final List<@NotNull String> arguments = redefinition.arguments;
             if (arguments == null) {
-                result.addAll(redefinition.redefinedTo);
+                if (redefinition.redefinedTo.isEmpty()) {
+                    // This is pointing to an empty redefinition (with no value)
+                    result.add(new ForeignLeafType(GLSLTokenTypes.PREPROCESSOR_REDEFINED, ""));
+                } else {
+                    // This is pointing to non-empty redefinition (has any value)
+                    result.addAll(redefinition.redefinedTo);
+                }
             } else {
                 // This is a function macro
                 if (parent.getTokenType() != GLSLTokenTypes.LEFT_PAREN) {

--- a/src/main/java/glslplugin/lang/parser/PreprocessorPsiBuilderAdapter.java
+++ b/src/main/java/glslplugin/lang/parser/PreprocessorPsiBuilderAdapter.java
@@ -132,6 +132,10 @@ public class PreprocessorPsiBuilderAdapter {
             parent.remapCurrentToken(GLSLTokenTypes.PREPROCESSOR_REDEFINED);
             parent.advanceLexer();
 
+            if (redefinition.redefinedTo.isEmpty()) {
+                result.add(new ForeignLeafType(GLSLTokenTypes.PREPROCESSOR_REDEFINED, ""));
+            }
+
             final List<@NotNull String> arguments = redefinition.arguments;
             if (arguments == null) {
                 result.addAll(redefinition.redefinedTo);


### PR DESCRIPTION
When writing something like this
```glsl
#define FOO
#define BAR FOO
```

IntelliJ constantly encounters the following errors:
<details>
  <summary>Stacktrace</summary>
  
  ```
  java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:359)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at glslplugin.lang.parser.PreprocessorPsiBuilderAdapter.getTokenType(PreprocessorPsiBuilderAdapter.java:264)
	at glslplugin.lang.parser.GLSLParsingBase.getTokenType(GLSLParsingBase.java:108)
	at glslplugin.lang.parser.GLSLParsing.parsePreprocessor(GLSLParsing.java:272)
	at glslplugin.lang.parser.GLSLParsingBase.flushPreprocessor(GLSLParsingBase.java:62)
	at glslplugin.lang.parser.GLSLParsingBase.eof(GLSLParsingBase.java:76)
	at glslplugin.lang.parser.GLSLParsing.parseTranslationUnit(GLSLParsing.java:352)
	at glslplugin.lang.parser.GLSLParser.parse(GLSLParser.java:48)
	at com.intellij.psi.tree.ILazyParseableElementType.doParseContents(ILazyParseableElementType.java:58)
	at com.intellij.psi.tree.IFileElementType.parseContents(IFileElementType.java:53)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.lambda$ensureParsed$2(LazyParseableElement.java:175)
	at com.intellij.psi.impl.DebugUtil.performPsiModification(DebugUtil.java:481)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.ensureParsed(LazyParseableElement.java:174)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.getFirstChildNode(LazyParseableElement.java:226)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.getFirstChildNode(LazyParseableElement.java:24)
	at com.intellij.psi.impl.BlockSupportImpl.isReplaceWholeNode(BlockSupportImpl.java:418)
	at com.intellij.psi.impl.BlockSupportImpl.mergeTrees(BlockSupportImpl.java:365)
	at com.intellij.psi.impl.BlockSupportImpl.makeFullParse(BlockSupportImpl.java:297)
	at com.intellij.psi.impl.BlockSupportImpl.reparse(BlockSupportImpl.java:92)
	at com.intellij.psi.impl.DocumentCommitThread.doCommit(DocumentCommitThread.java:261)
	at com.intellij.psi.impl.DocumentCommitThread.commitUnderProgress(DocumentCommitThread.java:128)
	at com.intellij.psi.impl.DocumentCommitThread.commitSynchronously(DocumentCommitThread.java:97)
	at com.intellij.psi.impl.PsiDocumentManagerBase.lambda$doCommit$9(PsiDocumentManagerBase.java:492)
	at com.intellij.psi.impl.PsiDocumentManagerBase.executeInsideCommit(PsiDocumentManagerBase.java:507)
	at com.intellij.psi.impl.PsiDocumentManagerBase.doCommit(PsiDocumentManagerBase.java:492)
	at com.intellij.psi.impl.PsiDocumentManagerBase.lambda$doCommit$8(PsiDocumentManagerBase.java:481)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:1023)
	at com.intellij.psi.impl.PsiDocumentManagerBase.doCommit(PsiDocumentManagerBase.java:481)
	at com.intellij.psi.impl.PsiDocumentManagerBase.commitDocument(PsiDocumentManagerBase.java:330)
	at com.intellij.psi.impl.source.codeStyle.lineIndent.FormatterBasedLineIndentProvider.getLineIndent(FormatterBasedLineIndentProvider.java:39)
	at com.intellij.application.options.CodeStyle.getLineIndent(CodeStyle.java:446)
	at com.intellij.codeInsight.editorActions.EnterHandler.adjustLineIndentNoCommit(EnterHandler.java:311)
	at com.intellij.codeInsight.editorActions.EnterHandler$DoEnterAction.run(EnterHandler.java:436)
	at com.intellij.codeInsight.editorActions.EnterHandler.executeWriteActionInner(EnterHandler.java:162)
	at com.intellij.codeInsight.editorActions.EnterHandler.lambda$executeWriteAction$0(EnterHandler.java:64)
	at com.intellij.psi.impl.source.PostprocessReformattingAspect.lambda$disablePostprocessFormattingInside$2(PostprocessReformattingAspect.java:120)
	at com.intellij.psi.impl.source.PostprocessReformattingAspect.disablePostprocessFormattingInside(PostprocessReformattingAspect.java:128)
	at com.intellij.psi.impl.source.PostprocessReformattingAspect.disablePostprocessFormattingInside(PostprocessReformattingAspect.java:119)
	at com.intellij.codeInsight.editorActions.EnterHandler.executeWriteAction(EnterHandler.java:63)
	at com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler$1.run(EditorWriteActionHandler.java:52)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:1023)
	at com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler.doExecute(EditorWriteActionHandler.java:66)
	at com.intellij.openapi.editor.actionSystem.EditorActionHandler.execute(EditorActionHandler.java:202)
	at com.intellij.codeInsight.template.impl.editorActions.EnterHandler.executeWriteAction(EnterHandler.java:49)
	at com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler$1.run(EditorWriteActionHandler.java:52)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:1023)
	at com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler.doExecute(EditorWriteActionHandler.java:66)
	at com.intellij.openapi.editor.actionSystem.EditorActionHandler.lambda$execute$2(EditorActionHandler.java:192)
	at com.intellij.openapi.editor.actionSystem.EditorActionHandler.doIfEnabled(EditorActionHandler.java:89)
	at com.intellij.openapi.editor.actionSystem.EditorActionHandler.lambda$execute$3(EditorActionHandler.java:191)
	at com.intellij.openapi.editor.impl.CaretModelImpl.lambda$runForEachCaret$3(CaretModelImpl.java:312)
	at com.intellij.openapi.editor.impl.CaretModelImpl.doWithCaretMerging(CaretModelImpl.java:421)
	at com.intellij.openapi.editor.impl.CaretModelImpl.runForEachCaret(CaretModelImpl.java:321)
	at com.intellij.openapi.editor.impl.CaretModelImpl.runForEachCaret(CaretModelImpl.java:296)
	at com.intellij.openapi.editor.actionSystem.EditorActionHandler.execute(EditorActionHandler.java:189)
	at com.intellij.xdebugger.impl.actions.handlers.XDebuggerSmartStepIntoHandler$SmartStepEditorActionHandler.doExecute(XDebuggerSmartStepIntoHandler.java:417)
	at com.intellij.openapi.editor.actionSystem.DynamicEditorActionHandler.doExecute(DynamicEditorActionHandler.java:63)
	at com.intellij.openapi.editor.actionSystem.EditorActionHandler.lambda$execute$4(EditorActionHandler.java:199)
	at com.intellij.openapi.editor.actionSystem.EditorActionHandler.doIfEnabled(EditorActionHandler.java:89)
	at com.intellij.openapi.editor.actionSystem.EditorActionHandler.execute(EditorActionHandler.java:198)
	at com.intellij.openapi.editor.actionSystem.EditorAction.lambda$actionPerformed$0(EditorAction.java:93)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:219)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:174)
	at com.intellij.openapi.editor.actionSystem.EditorAction.actionPerformed(EditorAction.java:102)
	at com.intellij.openapi.editor.actionSystem.EditorAction.actionPerformed(EditorAction.java:77)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.doPerformActionOrShowPopup(ActionUtil.java:315)
	at com.intellij.openapi.keymap.impl.ActionProcessor.performAction(ActionProcessor.java:47)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher$1.performAction(IdeKeyEventDispatcher.java:595)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.lambda$doPerformActionInner$9(IdeKeyEventDispatcher.java:717)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.openapi.application.TransactionGuardImpl.performUserActivity(TransactionGuardImpl.java:94)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.lambda$doPerformActionInner$10(IdeKeyEventDispatcher.java:717)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.performDumbAwareWithCallbacks(ActionUtil.java:337)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.doPerformActionInner(IdeKeyEventDispatcher.java:714)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.processAction(IdeKeyEventDispatcher.java:658)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.processAction(IdeKeyEventDispatcher.java:606)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.processActionOrWaitSecondStroke(IdeKeyEventDispatcher.java:489)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.inInitState(IdeKeyEventDispatcher.java:478)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.dispatchKeyEvent(IdeKeyEventDispatcher.java:229)
	at com.intellij.ide.IdeEventQueue.dispatchKeyEvent(IdeEventQueue.java:824)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:760)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$6(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:791)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$7(IdeEventQueue.java:449)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:113)
	at com.intellij.ide.IdeEventQueue.performActivity(IdeEventQueue.java:624)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:447)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:493)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
  ```
</details>
