### PR TITLE
Improved indentation for multi-line call and switch case

### DIFF
--- a/src/main/java/glslplugin/formatter/GLSLCodeStyleSettingsProvider.java
+++ b/src/main/java/glslplugin/formatter/GLSLCodeStyleSettingsProvider.java
@@ -63,12 +63,20 @@ public class GLSLCodeStyleSettingsProvider extends LanguageCodeStyleSettingsProv
 				    layout(column_major) mat4 modelview;
 				} matrices[3];
 
-				void main() {
-				    func();
-				}
-
 				vec3 addVectors(vec3 a, vec3 b) {
 				    return a + b;
+				}
+
+				void main() {
+				    func();
+				    addVectors(
+				    		vec3(4, 5, 6),
+				    		vec3(
+									1,
+									2,
+									3
+				    		)
+				    );
 				}
 
 				void miscFunc(int t) {

--- a/src/main/java/glslplugin/formatter/GLSLFormattingBlock.java
+++ b/src/main/java/glslplugin/formatter/GLSLFormattingBlock.java
@@ -32,6 +32,7 @@ import com.intellij.psi.tree.IElementType;
 import glslplugin.lang.elements.GLSLTokenTypes;
 import glslplugin.lang.elements.declarations.GLSLStructDefinition;
 import glslplugin.lang.elements.declarations.GLSLStructMemberDeclaration;
+import glslplugin.lang.elements.expressions.GLSLParameterList;;
 import glslplugin.lang.elements.statements.GLSLCompoundStatement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,6 +57,10 @@ public class GLSLFormattingBlock extends AbstractBlock {
         return psiElement instanceof GLSLCompoundStatement || psiElement instanceof GLSLStructMemberDeclaration;
     }
 
+    private static boolean isContinuationBlock(PsiElement psiElement) {
+        return psiElement instanceof GLSLParameterList;
+    }
+
     private static Indent getNodeIndent(ASTNode node) {
         IElementType nodeType = node.getElementType();
         ASTNode parent = node.getTreeParent();
@@ -69,6 +74,8 @@ public class GLSLFormattingBlock extends AbstractBlock {
                 return Indent.getNoneIndent();
             }
             return Indent.getNormalIndent();
+        } else if (isContinuationBlock(parentPsi)) {
+            return Indent.getContinuationIndent();
         }
 
         return Indent.getNoneIndent();

--- a/src/main/java/glslplugin/lang/parser/GLSLParsing.java
+++ b/src/main/java/glslplugin/lang/parser/GLSLParsing.java
@@ -776,12 +776,38 @@ public class GLSLParsing extends GLSLParsingBase {
         return true;
     }
 
+    private void parseCaseStatementList() {
+        // same as parseStatementList() but check for case/default keyword
+
+        while ((STATEMENT_FIRST_SET.contains(getTokenType())
+            && getTokenType() != CASE_KEYWORD
+            && getTokenType() != DEFAULT_KEYWORD || OPERATORS.contains(getTokenType()) || getTokenType() == PRECISION_KEYWORD) && !eof()) {
+            if (!parseStatement()) {
+                return;
+            }
+        }
+    }
+
+    private void parseCaseBlock() {
+        // case_block: ':' '}'
+        //                   | ':' statement_list case keyword
+        //                   | ':' statement_list default keyword
+        Marker mark = mark();
+        match(COLON, "Expected ':'");
+        if (eof(mark)) return;
+        if (getTokenType() != RIGHT_BRACE || getTokenType() != CASE_KEYWORD) {
+            parseCaseStatementList();
+        }
+        if (eof(mark)) return;
+        mark.done(COMPOUND_STATEMENT);
+    }
+
     private boolean parseCaseStatement() {
         // case_statement: 'case' constant_expression ':'
         Marker mark = mark();
         match(CASE_KEYWORD, "Expected 'case'");
         parseConstantExpression();
-        match(COLON, "Expected ':'");
+        parseCaseBlock();
         mark.done(CASE_STATEMENT);
         return true;
     }

--- a/testfiles/ContinuationIndent.glsl
+++ b/testfiles/ContinuationIndent.glsl
@@ -1,0 +1,34 @@
+vec2 foo = vec2(
+    1.0, // Should gets indented
+    2.0
+);
+
+float arr[5] = float[](
+    1.0, // Should gets indented
+    2.0, 3.0,
+    4.0, 5.0
+);
+
+void sum(vec4 a, vec4 b, out vec4 c) {
+    c = a + b;
+}
+
+void main() {
+    vec4 result = vec4(0.0);
+
+    sum(
+        vec4(
+            1.0, // Should gets double indented
+            2.0,
+            3.0,
+            4.0
+        ),
+        vec4(
+            5.0,
+            6.0,
+            7.0,
+            8.0
+        ),
+        result
+    );
+}

--- a/testfiles/SwitchStatement.glsl
+++ b/testfiles/SwitchStatement.glsl
@@ -1,0 +1,27 @@
+#version 330
+
+in int someValue;
+
+out vec4 fragColor;
+
+void main() {
+    switch (someValue) {
+        case 0:
+            // Should be indented acoording to setting
+            fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+            break;
+        case 1:
+            // Should be indented acoording to setting
+            vec4 a = vec4(1.0, 0.0, 0.0, 1.0);
+            vec4 b = vec4(0.0, 1.0, 0.0, 1.0);
+            fragColor = a + b;
+            break;
+        case 2:// Don't do anything here
+        default :// Same as above
+    }
+}
+
+void switchAtEOFWithBlock() {
+switch (someValue) {
+case 0:
+fragColor = vec4(1.0, 0.0, 0.0, 1.0);// Error here


### PR DESCRIPTION
## Multi-line call, aka. continuation indent in IDEA setting
Before:
```
vec3(
1.0,
2.0,
3.0
)
```
After, with continuation indent of 8 (default):
```
vec3(
        1.0,
        2.0,
        3.0,
)
```

## Switch case
Before:
```
switch (i) {
    case 0:
    foo();
    break;
    case 1:
    bar():
    break;
    default:
    baz();
    break;
}
```
After:

```
switch (i) {
    case 0:
        foo();
        break;
    case 1:
        bar():
        break;
    default:
        baz();
        break;
}
```