### PR TITLE
Fix GLSL macro rename behavior

### DIFF
--- a/src/main/java/glslplugin/lang/elements/preprocessor/GLSLMacroReference.java
+++ b/src/main/java/glslplugin/lang/elements/preprocessor/GLSLMacroReference.java
@@ -3,7 +3,9 @@ package glslplugin.lang.elements.preprocessor;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReferenceBase;
 import com.intellij.util.ArrayUtilRt;
+import com.intellij.util.IncorrectOperationException;
 import glslplugin.lang.elements.GLSLElement;
+import glslplugin.lang.elements.reference.GLSLReferencableDeclaration;
 import glslplugin.lang.elements.reference.GLSLReferenceUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,16 +13,24 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class GLSLMacroReference extends PsiReferenceBase<PsiElement> {
+    private final @NotNull PsiElement identifier;
     private final @NotNull String tokenName;
 
     public GLSLMacroReference(@NotNull PsiElement element, @NotNull PsiElement identifier) {
         super(element, GLSLReferenceUtil.rangeOfIn(identifier, element), false);
+        this.identifier = identifier;
         tokenName = Objects.requireNonNullElse(GLSLElement.text(identifier), "");
     }
 
     @Override
     public @Nullable GLSLDefineDirective resolve() {
         return GLSLDefineDirective.findActiveDefinitionBefore(getElement(), tokenName);
+    }
+
+    @Override
+    public PsiElement handleElementRename(@NotNull String newElementName) throws IncorrectOperationException {
+        GLSLReferencableDeclaration.replaceIdentifier(identifier, newElementName);
+        return getElement();
     }
 
     @Override

--- a/src/main/java/glslplugin/lang/elements/reference/GLSLAbstractReference.java
+++ b/src/main/java/glslplugin/lang/elements/reference/GLSLAbstractReference.java
@@ -1,6 +1,7 @@
 package glslplugin.lang.elements.reference;
 
 import com.intellij.diagnostic.PluginException;
+import com.intellij.lang.ASTNode;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
@@ -9,9 +10,11 @@ import com.intellij.psi.PsiPolyVariantReferenceBase;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.PsiReferenceBase;
 import com.intellij.psi.ResolveResult;
+import com.intellij.psi.impl.source.codeStyle.CodeEditUtil;
 import com.intellij.util.ArrayUtilRt;
 import com.intellij.util.IncorrectOperationException;
 import glslplugin.lang.elements.GLSLElement;
+import glslplugin.lang.elements.preprocessor.GLSLRedefinedToken;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -89,9 +92,18 @@ public abstract class GLSLAbstractReference<T extends GLSLReferencingElement> im
         }
         final TextRange newRange = new TextRange(renameRange.getStartOffset(), renameRange.getStartOffset() + newCombinedName.length());
 
-        final PsiElement renamedIdentifier = GLSLReferencableDeclaration.replaceIdentifier(identifier, newCombinedName);
+        if (identifier instanceof GLSLRedefinedToken) {
+            assert identifier == element;
+            final GLSLRedefinedToken token = new GLSLRedefinedToken(newCombinedName);
+            CodeEditUtil.setNodeGenerated(token, true);
+            final ASTNode identifierNode = identifier.getNode();
+            identifierNode.getTreeParent().replaceChild(identifierNode, token);
+            return token;
+        }
+
+        GLSLReferencableDeclaration.replaceIdentifier(identifier, newCombinedName);
         rangeInElement = newRange;
-        return identifier == element ? renamedIdentifier : element;
+        return element;
     }
 
     @Override

--- a/src/main/java/glslplugin/lang/elements/reference/GLSLAbstractReference.java
+++ b/src/main/java/glslplugin/lang/elements/reference/GLSLAbstractReference.java
@@ -1,7 +1,6 @@
 package glslplugin.lang.elements.reference;
 
 import com.intellij.diagnostic.PluginException;
-import com.intellij.lang.ASTNode;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
@@ -13,7 +12,6 @@ import com.intellij.psi.ResolveResult;
 import com.intellij.util.ArrayUtilRt;
 import com.intellij.util.IncorrectOperationException;
 import glslplugin.lang.elements.GLSLElement;
-import glslplugin.lang.elements.preprocessor.GLSLRedefinedToken;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -91,18 +89,9 @@ public abstract class GLSLAbstractReference<T extends GLSLReferencingElement> im
         }
         final TextRange newRange = new TextRange(renameRange.getStartOffset(), renameRange.getStartOffset() + newCombinedName.length());
 
-        if (identifier instanceof GLSLRedefinedToken) {
-            // Special case for GLSLRedefinedToken
-            assert identifier == element;
-            final GLSLRedefinedToken token = new GLSLRedefinedToken(newCombinedName);
-            final ASTNode identifierNode = identifier.getNode();
-            identifierNode.getTreeParent().replaceChild(identifierNode, token);
-            return token;
-        } else {
-            GLSLReferencableDeclaration.replaceIdentifier(identifier, newCombinedName);
-            rangeInElement = newRange;
-            return element;
-        }
+        final PsiElement renamedIdentifier = GLSLReferencableDeclaration.replaceIdentifier(identifier, newCombinedName);
+        rangeInElement = newRange;
+        return identifier == element ? renamedIdentifier : element;
     }
 
     @Override

--- a/src/main/java/glslplugin/lang/elements/reference/GLSLReferencableDeclaration.java
+++ b/src/main/java/glslplugin/lang/elements/reference/GLSLReferencableDeclaration.java
@@ -43,11 +43,12 @@ public interface GLSLReferencableDeclaration extends GLSLElement, PsiNameIdentif
     @NotNull
     String declaredNoun();
 
-    static void replaceIdentifier(PsiElement oldIdentifier, @NotNull String name) throws IncorrectOperationException {
+    static @NotNull PsiElement replaceIdentifier(PsiElement oldIdentifier, @NotNull String name) throws IncorrectOperationException {
         if (oldIdentifier == null) throw new IncorrectOperationException("No name to rename");
         ASTNode newNameNode = GLSLPsiElementFactory.createIdentifier(oldIdentifier.getProject(), name);
         final ASTNode oldIdentifierNode = oldIdentifier.getNode();
         oldIdentifierNode.getTreeParent().replaceChild(oldIdentifierNode, newNameNode);
+        return newNameNode.getPsi();
     }
 
     static void replacePreprocessorString(PsiElement oldPreprocessorString, @NotNull String name) throws IncorrectOperationException {

--- a/src/test/java/glslplugin/LightGLSLTestCase.java
+++ b/src/test/java/glslplugin/LightGLSLTestCase.java
@@ -8,6 +8,9 @@ import glslplugin.lang.parser.GLSLFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
 
 /**
  * Base for light test cases
@@ -17,6 +20,43 @@ public abstract class LightGLSLTestCase extends BasePlatformTestCase {
     @Override
     protected String getTestDataPath() {
         return new File("testdata").getAbsolutePath();
+    }
+
+    private static void allowBuiltinResourceRootAccess() {
+        final URL builtinUrl = LightGLSLTestCase.class.getClassLoader().getResource("glsl/builtin.glsl");
+        if (builtinUrl == null) {
+            return;
+        }
+
+        try {
+            if ("jar".equals(builtinUrl.getProtocol())) {
+                final String urlText = builtinUrl.toString();
+                final int separator = urlText.indexOf("!/");
+                if (separator < 0) {
+                    return;
+                }
+                final URL jarUrl = new URL(urlText.substring("jar:".length(), separator));
+                allowVfsRootAccess(Path.of(jarUrl.toURI()).toString());
+            } else if ("file".equals(builtinUrl.getProtocol())) {
+                allowVfsRootAccess(Path.of(builtinUrl.toURI()).toString());
+            }
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException("Failed to allow GLSL builtin resource root", e);
+        }
+    }
+
+    private static void allowVfsRootAccess(String root) {
+        String roots = System.getProperty("vfs.additional-allowed-roots");
+        if (roots == null || roots.isEmpty()) {
+            roots = root;
+        } else {
+            roots = roots + File.pathSeparator + root;
+        }
+        System.setProperty("vfs.additional-allowed-roots", roots);
+    }
+
+    static {
+        allowBuiltinResourceRootAccess();
     }
 
     private File getTestFile(String fileName){

--- a/src/test/java/glslplugin/lang/MacroReferenceTest.java
+++ b/src/test/java/glslplugin/lang/MacroReferenceTest.java
@@ -424,4 +424,74 @@ public class MacroReferenceTest extends LightGLSLTestCase {
         assertEquals(GLSLTokenTypes.IDENTIFIER, nameIdentifier.getNode().getElementType());
         assertEquals("LIGHT_COUNT", nameIdentifier.getText());
     }
+
+    public void testRenameObjectLikeMacroInSameFile() {
+        myFixture.configureByText(GLSLFileType.INSTANCE, """
+            #define FOO 123.0
+
+            void main() {
+                float x = F<caret>OO;
+            }
+            """);
+
+        myFixture.renameElementAtCaret("BAR");
+
+        myFixture.checkResult("""
+            #define BAR 123.0
+
+            void main() {
+                float x = BAR;
+            }
+            """);
+    }
+
+    public void testRenameIncludedObjectLikeMacroUpdatesAllReferences() {
+        PsiFile commonFile = addProjectShaderFile("shaders/common.glsl", "#define FOO 123.0\n");
+        configureProjectShaderFile("shaders/main.glsl", """
+            #include "common.glsl"
+
+            void main() {
+                float x = F<caret>OO;
+            }
+
+            #ifdef FOO
+            #endif
+            """);
+
+        myFixture.renameElementAtCaret("BAR");
+
+        assertEquals("#define BAR 123.0\n", commonFile.getText());
+        myFixture.checkResult("""
+            #include "common.glsl"
+
+            void main() {
+                float x = BAR;
+            }
+
+            #ifdef BAR
+            #endif
+            """);
+    }
+
+    public void testRenameIncludedFunctionLikeMacroUpdatesInvocation() {
+        configureProjectShaderFile("shaders/common.glsl", "#define SCA<caret>LE(x) ((x) * 2.0)\n");
+        PsiFile mainFile = addProjectShaderFile("shaders/main.glsl", """
+            #include "common.glsl"
+
+            void main() {
+                float x = SCALE(1.0);
+            }
+            """);
+
+        myFixture.renameElementAtCaret("DOUBLE");
+
+        myFixture.checkResult("#define DOUBLE(x) ((x) * 2.0)\n");
+        assertEquals("""
+            #include "common.glsl"
+
+            void main() {
+                float x = DOUBLE(1.0);
+            }
+            """, mainFile.getText());
+    }
 }

--- a/src/test/java/glslplugin/lang/MacroReferenceTest.java
+++ b/src/test/java/glslplugin/lang/MacroReferenceTest.java
@@ -47,19 +47,27 @@ public class MacroReferenceTest extends LightGLSLTestCase {
 
     private void assertRedefinedTokenHighlight(String text) {
         final String documentText = myFixture.getEditor().getDocument().getText();
-        final int startOffset = documentText.indexOf(text);
-        assertTrue(startOffset >= 0);
-        final int endOffset = startOffset + text.length();
 
         for (HighlightInfo info : myFixture.doHighlighting()) {
-            if (info.startOffset == startOffset
-                && info.endOffset == endOffset
+            if (info.endOffset <= documentText.length()
+                && info.startOffset >= 0
+                && documentText.substring(info.startOffset, info.endOffset).equals(text)
                 && info.forcedTextAttributesKey == GLSLHighlighter.GLSL_REDEFINED_TOKEN[0]) {
                 return;
             }
         }
 
         fail("Expected macro highlight for " + text);
+    }
+
+    private void openFileAtLastText(PsiFile file, String text) {
+        assertNotNull(file.getVirtualFile());
+        myFixture.openFileInEditor(file.getVirtualFile());
+
+        final String documentText = myFixture.getEditor().getDocument().getText();
+        final int offset = documentText.lastIndexOf(text);
+        assertTrue(offset >= 0);
+        myFixture.getEditor().getCaretModel().moveToOffset(offset);
     }
 
     public void testObjectLikeMacroReferenceResolvesToDefineDirective() {
@@ -443,6 +451,7 @@ public class MacroReferenceTest extends LightGLSLTestCase {
                 float x = BAR;
             }
             """);
+        assertRedefinedTokenHighlight("BAR");
     }
 
     public void testRenameIncludedObjectLikeMacroUpdatesAllReferences() {
@@ -493,5 +502,48 @@ public class MacroReferenceTest extends LightGLSLTestCase {
                 float x = DOUBLE(1.0);
             }
             """, mainFile.getText());
+    }
+
+    public void testRepeatedRenameKeepsSameFileMacroReferencesActive() {
+        configureProjectShaderFile("shaders/common.glsl", """
+            #define F<caret>OO 123.0
+
+            void common() {
+                float y = FOO;
+            }
+            """);
+        PsiFile commonFile = myFixture.getFile();
+        PsiFile mainFile = addProjectShaderFile("shaders/main.glsl", """
+            #include "common.glsl"
+
+            void main() {
+                float x = FOO;
+            }
+            """);
+
+        myFixture.renameElementAtCaret("BAR");
+
+        myFixture.checkResult("""
+            #define BAR 123.0
+
+            void common() {
+                float y = BAR;
+            }
+            """);
+        assertRedefinedTokenHighlight("BAR");
+
+        openFileAtLastText(mainFile, "BAR");
+        myFixture.renameElementAtCaret("BAZ");
+
+        assertEquals("""
+            #define BAZ 123.0
+
+            void common() {
+                float y = BAZ;
+            }
+            """, commonFile.getText());
+
+        openFileAtLastText(commonFile, "BAZ");
+        assertRedefinedTokenHighlight("BAZ");
     }
 }

--- a/src/test/java/glslplugin/lang/SemanticHighlightingTest.java
+++ b/src/test/java/glslplugin/lang/SemanticHighlightingTest.java
@@ -1,14 +1,21 @@
 package glslplugin.lang;
 
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationAction;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.NavigatablePsiElement;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
 import glslplugin.GLSLHighlighter;
 import glslplugin.LightGLSLTestCase;
+import glslplugin.lang.elements.declarations.GLSLDeclarator;
 import glslplugin.lang.elements.declarations.GLSLFunctionDeclaration;
 import glslplugin.lang.elements.declarations.GLSLInterfaceBlockDefinition;
 import glslplugin.lang.elements.expressions.GLSLFunctionOrConstructorCallExpression;
+import glslplugin.lang.elements.reference.GLSLBuiltInPsiUtilService;
+import glslplugin.lang.parser.GLSLFile;
 
 import java.io.File;
 import java.io.IOException;
@@ -191,6 +198,56 @@ public class SemanticHighlightingTest extends LightGLSLTestCase {
         }
         assertTrue("Missing function call highlight", found);
         assertSame(DefaultLanguageHighlighterColors.FUNCTION_CALL, GLSLHighlighter.GLSL_CONSTRUCTOR_CALL[0].getFallbackAttributeKey());
+    }
+
+    public void testBuiltinsFilePreservesResourceName() {
+        GLSLFile builtinsFile = getProject().getService(GLSLBuiltInPsiUtilService.class).getBuiltinsFile();
+
+        assertNotNull(builtinsFile);
+        assertEquals("builtin.glsl", builtinsFile.getName());
+        assertFalse(builtinsFile.getViewProvider().getVirtualFile().isWritable());
+        assertNotLightVirtualFile(builtinsFile.getViewProvider().getVirtualFile());
+    }
+
+    public void testBuiltinVariableIsGotoDeclarationTarget() {
+        myFixture.configureByText(GLSLFileType.INSTANCE, """
+                #version 140
+
+                void main() {
+                    vec4 color = gl_Frag<caret>Coord;
+                }
+                """);
+
+        PsiElement target = findGotoTargetAtCaret();
+
+        assertTrue("Expected GLSLDeclarator, got " + target, target instanceof GLSLDeclarator);
+        assertEquals("gl_FragCoord", ((GLSLDeclarator) target).getName());
+        assertNavigableBuiltinTarget(target);
+    }
+
+    private PsiElement findGotoTargetAtCaret() {
+        return GotoDeclarationAction.findTargetElement(
+                getProject(),
+                myFixture.getEditor(),
+                myFixture.getCaretOffset()
+        );
+    }
+
+    private void assertNavigableBuiltinTarget(PsiElement target) {
+        assertNotNull(target);
+        assertTrue("Expected navigable target, got " + target, target instanceof NavigatablePsiElement);
+        assertTrue("Expected target to be navigable: " + target, ((NavigatablePsiElement) target).canNavigate());
+
+        final PsiFile containingFile = target.getContainingFile();
+        assertNotNull(containingFile);
+        assertEquals("builtin.glsl", containingFile.getName());
+        assertNotNull(containingFile.getVirtualFile());
+        assertNotLightVirtualFile(containingFile.getVirtualFile());
+    }
+
+    private void assertNotLightVirtualFile(VirtualFile file) {
+        assertFalse("Expected real VFS builtin resource, got " + file.getClass().getName(),
+                file.getClass().getName().contains("LightVirtualFile"));
     }
 
     static {


### PR DESCRIPTION
This PR fixes inconsistent GLSL macro rename behavior across same-file and included-file references.

Changes:
- Fix rename crashes for macro-expanded tokens (`java.lang.Throwable: Assertion failed: for not generated items old indentation must be defined: element=PsiElement(PREPROCESSOR_REDEFINED)`).
- Preserve same-file macro references after rename.
- Support renaming macro references in included files.
- Support object-like, function-like, and preprocessor directive macro references.
- Add regression tests for same-file rename, included macro rename, repeated rename, and built-in resource navigation behavior.